### PR TITLE
Wait for kubelet CSR before approving it during node provisioning

### DIFF
--- a/lib/kubernetes/client.rb
+++ b/lib/kubernetes/client.rb
@@ -45,6 +45,18 @@ class Kubernetes::Client
     kubectl("delete node :node_name", node_name:)
   end
 
+  def get_pending_csr(node_name)
+    kubectl("get csr --sort-by=.metadata.creationTimestamp | awk '/Pending/ && /kubelet-serving/ && /':node_name'/ {print $1}' | tail -1", node_name:).chomp
+  end
+
+  def get_approved_csr(node_name)
+    kubectl("get csr --sort-by=.metadata.creationTimestamp | awk '/Approved/ && /kubelet-serving/ && /':node_name'/ {print $1}' | tail -1", node_name:).chomp
+  end
+
+  def approve_csr(csr_name)
+    kubectl("certificate approve :csr_name", csr_name:)
+  end
+
   def set_load_balancer_hostname(svc, hostname)
     patch_data = JSON.generate({
       "status" => {

--- a/prog/kubernetes/provision_kubernetes_node.rb
+++ b/prog/kubernetes/provision_kubernetes_node.rb
@@ -236,7 +236,12 @@ CONFIG
   end
 
   label def approve_new_csr
-    kubernetes_cluster.sshable.cmd("sudo kubectl --kubeconfig /etc/kubernetes/admin.conf get csr | awk '/Pending/ && /kubelet-serving/ && /':name'/ {print $1}' | xargs -r sudo kubectl --kubeconfig /etc/kubernetes/admin.conf certificate approve", name: node.name)
+    approved_csr = kubernetes_cluster.client.get_approved_csr(node.name)
+    if approved_csr.empty?
+      pending_csr = kubernetes_cluster.client.get_pending_csr(node.name)
+      nap 5 if pending_csr.empty?
+      kubernetes_cluster.client.approve_csr(pending_csr)
+    end
     kubernetes_cluster.incr_sync_internal_dns_config
     kubernetes_cluster.incr_sync_worker_mesh
     pop({node_id: node.id})

--- a/spec/lib/kubernetes/client_spec.rb
+++ b/spec/lib/kubernetes/client_spec.rb
@@ -229,6 +229,30 @@ RSpec.describe Kubernetes::Client do
     end
   end
 
+  describe "get_pending_csr" do
+    it "returns the pending csr name for the node" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("csr-abc123\n", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk '/Pending/ && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
+      expect(kubernetes_client.get_pending_csr("my-node")).to eq("csr-abc123")
+    end
+  end
+
+  describe "get_approved_csr" do
+    it "returns the approved csr name for the node" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("csr-xyz789\n", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf get csr --sort-by=.metadata.creationTimestamp | awk '/Approved/ && /kubelet-serving/ && /'my-node'/ {print $1}' | tail -1").and_return(response)
+      expect(kubernetes_client.get_approved_csr("my-node")).to eq("csr-xyz789")
+    end
+  end
+
+  describe "approve_csr" do
+    it "approves the given csr" do
+      response = Net::SSH::Connection::Session::StringWithExitstatus.new("approved", 0)
+      expect(session).to receive(:_exec!).with("sudo kubectl --kubeconfig=/etc/kubernetes/admin.conf certificate approve csr-abc123").and_return(response)
+      kubernetes_client.approve_csr("csr-abc123")
+    end
+  end
+
   describe "set_load_balancer_hostname" do
     it "calls kubectl function with right inputs" do
       svc = {


### PR DESCRIPTION
The metrics server requires manually approving the kubelet-serving CSR whenever a new node joins the cluster. The previous code ran the approval immediately after installing the CNI, but sometimes the kubelet had not yet created the CSR by that point, causing the approval to silently do nothing.

The label now checks whether the CSR is already approved first, skipping approval entirely on retries. If not yet approved, it looks for a pending CSR and approves it. If neither exists, it naps to wait for the kubelet to create one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Kubernetes node provisioning with improved Certificate Signing Request management. The system now handles CSR retrieval and approval through the cluster client API, providing better control and visibility into node authentication flows.

* **Tests**
  * Expanded test coverage for Certificate Signing Request operations including pending request retrieval, approved request detection, and approval workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->