### PR TITLE
Clean up SPDK bdevs after migration to ubiblk.

### DIFF
--- a/prog/storage/migrate_spdk_vm_to_ubiblk.rb
+++ b/prog/storage/migrate_spdk_vm_to_ubiblk.rb
@@ -16,6 +16,14 @@ class Prog::Storage::MigrateSpdkVmToUbiblk < Prog::Base
       fail "Vm is already using Ubiblk"
     end
 
+    unless vm.vm_storage_volumes.first.use_bdev_ubi
+      fail "Vm storage volume does not use bdev_ubi"
+    end
+
+    unless vm.vm_storage_volumes.first.key_encryption_key_1
+      fail "Vm storage volume is not encrypted"
+    end
+
     unless vm.vm_host.vhost_block_backends.find { |b| b.version == Config.vhost_block_backend_version }
       fail "VmHost does not have the right vhost block backend installed"
     end

--- a/rhizome/host/bin/spdk-migration-helper
+++ b/rhizome/host/bin/spdk-migration-helper
@@ -24,9 +24,15 @@ when "create-vhost-backend-service-file"
 when "remove-spdk-controller"
   disk_index = params.fetch("disk_index")
   spdk_version = params.fetch("spdk_version")
+  device_id = "#{vm_name}_#{disk_index}"
   client_rpc = SpdkRpc.new(SpdkPath.rpc_sock(spdk_version))
+
   vhost_controller = SpdkPath.vhost_controller(vm_name, disk_index)
   client_rpc.vhost_delete_controller(vhost_controller)
+  client_rpc.bdev_ubi_delete(device_id)
+  client_rpc.bdev_crypto_delete("#{device_id}_base")
+  client_rpc.bdev_aio_delete("#{device_id}_aio")
+  client_rpc.accel_crypto_key_destroy("#{device_id}_key")
 
 else
   puts "Unknown action: #{action}"

--- a/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
+++ b/spec/prog/storage/migrate_spdk_vm_to_ubiblk_spec.rb
@@ -64,6 +64,20 @@ RSpec.describe Prog::Storage::MigrateSpdkVmToUbiblk do
         }.to raise_error("This prog only supports Vms with exactly one disk")
       end
 
+      it "fails if the vm storage volume does not use bdev_ubi" do
+        vm.vm_storage_volumes.first.update(use_bdev_ubi: false)
+        expect {
+          described_class.assemble(vm.id)
+        }.to raise_error("Vm storage volume does not use bdev_ubi")
+      end
+
+      it "fails if the vm storage volume is not encrypted" do
+        vm.vm_storage_volumes.first.update(key_encryption_key_1_id: nil)
+        expect {
+          described_class.assemble(vm.id)
+        }.to raise_error("Vm storage volume is not encrypted")
+      end
+
       it "fails if the vm has a ubiblk disk" do
         vm.vm_storage_volumes.first.update(vhost_block_backend_id: vm_host.vhost_block_backends.first.id, vring_workers: 1)
         expect {


### PR DESCRIPTION
The SPDK to ubiblk migration previously removed only the vhost controller, leaving behind the SPDK bdevs (ubi, crypto, aio) and the crypto key.

The bdev_aio instance kept an open file descriptor to `disk.raw.bk` (previously `disk.raw`). As a result, removing `disk.raw.bk` during the delayed cleanup step did not immediately free disk space until the bdev_aio instance was deleted or SPDK exited.

This PR removes the remaining SPDK bdevs once they are no longer needed. Since `bdev_crypto` and `bdev_ubi` depend on `bdev_aio`, they must be removed first before deleting the underlying `bdev_aio` instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced validation checks for VM storage configuration to ensure proper setup during migration operations.
  * Improved storage cleanup procedures during controller removal.

* **Tests**
  * Added test cases for storage configuration validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->