### PR TITLE
Encrypt swap partition during host setup

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -80,6 +80,13 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     end
     update_stack({"available_storage_gib" => vm_host.available_storage_gib})
 
+    hop_verify_encrypted_swap
+  end
+
+  label def verify_encrypted_swap
+    sshable = vm_host.sshable
+    swap_device = sshable.cmd("swapon --show=NAME --noheadings").strip
+    fail_test "swap is not on a dm-crypt device: #{swap_device}" unless swap_device.start_with?("/dev/dm-")
     hop_install_integration_specs
   end
 

--- a/rhizome/host/bin/encrypt-swap
+++ b/rhizome/host/bin/encrypt-swap
@@ -1,0 +1,55 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require "fileutils"
+
+fstab = File.read("/etc/fstab")
+swap_line = fstab.lines.find { |l| l.match?(/\bswap\b/) && !l.match?(/^\s*#/) }
+
+unless swap_line
+  warn "No swap line found in /etc/fstab"
+  exit 1
+end
+
+swap_source = swap_line.split.first
+
+# Resolve fstab swap source to a concrete device path we can realpath().
+swap_device = swap_source
+  .sub(/\AUUID=/, "/dev/disk/by-uuid/")
+  .sub(/\ALABEL=/, "/dev/disk/by-label/")
+
+# Pick a /dev/disk/by-id symlink that points to swap_device.
+swap_real = File.realpath(swap_device)
+by_id = Dir["/dev/disk/by-id/*"]
+  .find { |p| File.identical?(p, swap_real) }
+
+unless by_id
+  warn "No /dev/disk/by-id entry found for #{swap_device} (real=#{swap_real})"
+  exit 1
+end
+
+r "swapoff", swap_real
+
+# Ephemeral key via /dev/urandom (regenerated each boot); size=512 means AES-256-XTS (XTS halves the key).
+crypttab_entry = "cryptswap #{by_id} /dev/urandom cipher=aes-xts-plain64,size=512,swap,discard\n"
+if File.exist?("/etc/crypttab")
+  # backup crypttab before modifying in case something goes wrong
+  FileUtils.cp("/etc/crypttab", "/etc/crypttab.bak.#{Time.now.to_i}")
+  crypttab = File.read("/etc/crypttab")
+end
+safe_write_to_file("/etc/crypttab", crypttab.gsub(/^cryptswap\s.*\n?/, "") + crypttab_entry.to_s)
+
+# backup fstab before modifying in case something goes wrong
+FileUtils.cp("/etc/fstab", "/etc/fstab.bak.#{Time.now.to_i}")
+safe_write_to_file("/etc/fstab",
+  fstab.sub(swap_line, "/dev/mapper/cryptswap none swap sw 0 0\n"))
+
+# Prevent interactive prompt about existing swap signature on the backing device.
+r "wipefs", "-a", swap_real
+
+# Activate now (boot will recreate via crypttab)
+r "systemctl daemon-reload"
+r "systemctl restart systemd-cryptsetup@cryptswap.service"
+r "mkswap -f /dev/mapper/cryptswap"
+r "swapon -a"

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -100,6 +100,8 @@ r "tar xvf htcat.tar.gz -C /usr/local/bin/"
 
 SpdkSetup.prep
 
+r File.join(__dir__, "encrypt-swap")
+
 # cron job to store serial.log files
 FileUtils.mkdir_p("/var/log/ubicloud/serials")
 File.write("/etc/cron.d/ubicloud-clean-serial-logs", <<CRON)

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -98,9 +98,22 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait_setup_host }.to nap(15)
     end
 
-    it "hops to install_integration_specs if the host is ready" do
+    it "hops to verify_encrypted_swap if the host is ready" do
       expect(vm_host.strand).to receive(:label).and_return("wait").at_least(:once)
-      expect { hs_test.wait_setup_host }.to hop("install_integration_specs")
+      expect { hs_test.wait_setup_host }.to hop("verify_encrypted_swap")
+    end
+  end
+
+  describe "#verify_encrypted_swap" do
+    it "hops to install_integration_specs if swap is on dm-crypt" do
+      expect(vm_host.sshable).to receive(:_cmd).with("swapon --show=NAME --noheadings").and_return("/dev/dm-0\n")
+      expect { hs_test.verify_encrypted_swap }.to hop("install_integration_specs")
+    end
+
+    it "fails if swap is not on dm-crypt" do
+      expect(vm_host.sshable).to receive(:_cmd).with("swapon --show=NAME --noheadings").and_return("/dev/nvme0n1p2\n")
+      expect(hs_test.strand).to receive(:update).with(hash_including(exitval: {msg: "swap is not on a dm-crypt device: /dev/nvme0n1p2"}))
+      expect { hs_test.verify_encrypted_swap }.to hop("failed")
     end
   end
 


### PR DESCRIPTION
Set up dm-crypt on the swap partition with a random ephemeral key from /dev/urandom so swap contents are not readable after reboot or from a physically removed disk. The key is regenerated on every boot, which is fine since swap data is inherently ephemeral.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated tool to configure and enable encrypted swap during host preparation for improved data protection.
  * Host readiness now includes an explicit verification step that ensures swap is encrypted before proceeding with installation.

* **Tests**
  * Added tests covering encrypted-swap verification, including success (proceed) and failure (abort with clear error) scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->