### PR TITLE
UMI: make `archive-storage-volume` args consistent with `archive-url`.

### DIFF
--- a/rhizome/host/bin/archive-storage-volume
+++ b/rhizome/host/bin/archive-storage-volume
@@ -2,27 +2,40 @@
 # frozen_string_literal: true
 
 require "json"
-require "fileutils"
-require_relative "../../common/lib/util"
 require_relative "../lib/storage_archive"
-require_relative "../lib/vhost_block_backend"
 require_relative "../lib/storage_path"
+
+unless (vm_name = ARGV.shift)
+  puts "expected vm_name as argument"
+  exit 1
+end
+
+unless (device = ARGV.shift)
+  puts "expected device as argument"
+  exit 1
+end
+
+unless (disk_index = ARGV.shift)
+  puts "expected disk_index as argument"
+  exit 1
+end
+
+unless (vhost_block_backend_version = ARGV.shift)
+  puts "expected vhost_block_backend_version as argument"
+  exit 1
+end
 
 params = JSON.parse($stdin.read)
 
-validate_keys(
-  "archive-storage-volume parameters",
-  %w[vm_name device disk_index kek target_conf vhost_block_backend_version],
-  [],
-  params
-)
+unless (target_conf = params["target_conf"])
+  puts "expected target_conf in parameters"
+  exit 1
+end
 
-vm_name = params.fetch("vm_name")
-device = params.fetch("device")
-disk_index = params.fetch("disk_index")
-kek = params.fetch("kek")
-target_conf = params.fetch("target_conf")
-vhost_block_backend_version = params.fetch("vhost_block_backend_version")
+unless (kek = params["kek"])
+  puts "expected kek in parameters"
+  exit 1
+end
 
 storage_path = StoragePath.new(vm_name, device, disk_index)
 StorageArchive.new(


### PR DESCRIPTION
In 40019b3 we decided to make non-sensitive parameters of `archive-url` command line args instead of getting them from stdin.

This commit updates `archive-storage-volume` to do the same. The new command line usage is:

```
host/bin/archive-storage-volume VM DEVICE DISK_IDX VHOST_BACKEND_VERSION
```

The standard input payload contains `kek` and `target_conf`. For example:

```
payload = {
  "kek": {"algorithm": "aes-256-gcm", "key": "b64-encoded-32-byte-key"},
  "target_conf": {
     "endpoint": "https://s3-endpoint-url",
     "region": "auto",
     "bucket": "ubicloud-machine-images",
     "prefix": "pj1234567890/mi9876543210",
     "access_key_id": "valid-access-key-id",
     "secret_access_key": "valid-secret-access-key",
     "session_token": "optional-session-token",
     "archive_kek": {
       "algorithm": "aes-256-gcm",
       "key": "b64-encoded-32-byte-key"
     }
  }
}.to_json
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal refactoring of parameter handling in storage archive operations to improve code maintainability and reduce dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->