### PR TITLE
Refactor random key encryption key generation to a method.

### DIFF
--- a/model/storage_key_encryption_key.rb
+++ b/model/storage_key_encryption_key.rb
@@ -1,9 +1,23 @@
 # frozen_string_literal: true
 
+require "openssl"
+require "base64"
 require_relative "../model"
 
 class StorageKeyEncryptionKey < Sequel::Model
   plugin ResourceMethods, encrypted_columns: [:key, :init_vector]
+
+  def self.create_random(auth_data:, algorithm: "aes-256-gcm")
+    cipher = OpenSSL::Cipher.new(algorithm)
+    key = cipher.random_key
+    init_vector = cipher.random_iv
+    create(
+      algorithm:,
+      key: Base64.strict_encode64(key),
+      init_vector: Base64.strict_encode64(init_vector),
+      auth_data:
+    )
+  end
 
   def secret_key_material_hash
     # default to_hash doesn't decrypt encrypted columns, so implement

--- a/prog/rotate_storage_kek.rb
+++ b/prog/rotate_storage_kek.rb
@@ -10,19 +10,7 @@ class Prog::RotateStorageKek < Prog::Base
       pop "storage volume is not encrypted"
     end
 
-    key_wrapping_algorithm = "aes-256-gcm"
-    cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
-    key_wrapping_key = cipher.random_key
-    key_wrapping_iv = cipher.random_iv
-    auth_data = vm_storage_volume.device_id
-
-    key_encryption_key = StorageKeyEncryptionKey.create(
-      algorithm: key_wrapping_algorithm,
-      key: Base64.encode64(key_wrapping_key),
-      init_vector: Base64.encode64(key_wrapping_iv),
-      auth_data:
-    )
-
+    key_encryption_key = StorageKeyEncryptionKey.create_random(auth_data: vm_storage_volume.device_id)
     vm_storage_volume.update({key_encryption_key_2_id: key_encryption_key.id})
 
     hop_install

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -682,17 +682,7 @@ module Scheduling::Allocator
         end
 
         key_encryption_key = if volume["encrypted"]
-          key_wrapping_algorithm = "aes-256-gcm"
-          cipher = OpenSSL::Cipher.new(key_wrapping_algorithm)
-          key_wrapping_key = cipher.random_key
-          key_wrapping_iv = cipher.random_iv
-
-          StorageKeyEncryptionKey.create(
-            algorithm: key_wrapping_algorithm,
-            key: Base64.encode64(key_wrapping_key),
-            init_vector: Base64.encode64(key_wrapping_iv),
-            auth_data: "#{vm.inhost_name}_#{disk_index}"
-          )
+          StorageKeyEncryptionKey.create_random(auth_data: "#{vm.inhost_name}_#{disk_index}")
         end
 
         image_id = if volume["boot"]

--- a/spec/model/storage_key_encryption_key_spec.rb
+++ b/spec/model/storage_key_encryption_key_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+
+RSpec.describe StorageKeyEncryptionKey do
+  describe ".create_random" do
+    it "generates an aes-256-gcm random KEK by default" do
+      kek = described_class.create_random(auth_data: "some_auth_data")
+      expect(kek.algorithm).to eq("aes-256-gcm")
+      expect(Base64.strict_decode64(kek.key).bytesize).to eq(32)
+      expect(Base64.strict_decode64(kek.init_vector).bytesize).to eq(12)
+      expect(kek.auth_data).to eq("some_auth_data")
+    end
+
+    it "generates a random KEK with the specified algorithm" do
+      kek = described_class.create_random(auth_data: "some_auth_data", algorithm: "aes-128-gcm")
+      expect(kek.algorithm).to eq("aes-128-gcm")
+      expect(Base64.strict_decode64(kek.key).bytesize).to eq(16)
+      expect(Base64.strict_decode64(kek.init_vector).bytesize).to eq(12)
+      expect(kek.auth_data).to eq("some_auth_data")
+    end
+  end
+end


### PR DESCRIPTION
Added `StorageKeyEncryptionKey.create_random()`. This will be reused in UMI related progs where we need to generate a key encryption key for archives.

Also switched from `Base64.encode64()` to `Base64.strict_encode64()`, which complies with RFC 4648 and doesn't add new lines. The result is decodable using both strict and non-strict decoders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized and automated generation of storage encryption keys for encrypted volumes, simplifying key handling and improving security practices without altering user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->