### PR TITLE
Pykello/vmstats

### DIFF
--- a/prog/test/vm.rb
+++ b/prog/test/vm.rb
@@ -83,6 +83,16 @@ class Prog::Test::Vm < Prog::Test::Base
       sshable.cmd("sync :test_file", test_file:)
     }
 
+    hop_verify_vm_stats
+  end
+
+  label def verify_vm_stats
+    result = vm.vm_host.sshable.cmd_json("sudo host/bin/vm-stats :vm_name", vm_name: vm.inhost_name)
+    fail_test "missing expected keys in vm-stats output" unless result.keys.sort == ["disk_0", "vm"]
+    vm_stats = result["vm"]
+    fail_test "missing expected keys in vm stats" unless vm_stats.keys.sort == ["cpu_stats", "main_pid"]
+    disk_0_stats = result["disk_0"]
+    fail_test "missing expected keys in disk_0 stats" unless disk_0_stats.keys.sort == ["cpu_stats", "io_stats", "main_pid", "memory_peak_bytes", "memory_swap_peak_bytes"]
     hop_stop_semaphore
   end
 

--- a/prog/vm/metal/nexus.rb
+++ b/prog/vm/metal/nexus.rb
@@ -34,6 +34,7 @@ class Prog::Vm::Metal::Nexus < Prog::Base
     register_deadline(nil, 5 * 60)
     vm.active_billing_records.each(&:finalize)
     vm.assigned_vm_address&.active_billing_record&.finalize
+    log_vm_stats
   end
 
   label def start
@@ -624,5 +625,16 @@ class Prog::Vm::Metal::Nexus < Prog::Base
 
   def hard_stop
     host.sshable.cmd("sudo systemctl stop :vm_name", vm_name:)
+  end
+
+  def log_vm_stats
+    stats = host.sshable.cmd_json("sudo host/bin/vm-stats :vm_name", vm_name:)
+  rescue Sshable::SshError, JSON::ParserError => e
+    # Collecting VM stats is best effort during destroy, so we catch and log any
+    # errors without preventing the destroy process. If there are bugs in vm-stats,
+    # they should be also reproduced in E2E tests which will notify us.
+    Clog.emit("Failed to collect VM destroy stats", failed_vm_destroy_stats: Util.exception_to_hash(e))
+  else
+    Clog.emit("VM destroy stats", vm_destroy_stats: stats)
   end
 end

--- a/rhizome/host/bin/vm-stats
+++ b/rhizome/host/bin/vm-stats
@@ -1,0 +1,13 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/vm_stats"
+
+unless (vm_name = ARGV.shift)
+  warn "expected VM name"
+  exit 1
+end
+
+vm_stats = VmStats.new(vm_name)
+puts JSON.pretty_generate(vm_stats.collect)

--- a/rhizome/host/lib/vm_stats.rb
+++ b/rhizome/host/lib/vm_stats.rb
@@ -1,0 +1,93 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "vm_path"
+require_relative "../../common/lib/util"
+
+class VmStats
+  def initialize(vm_name)
+    @vm_name = vm_name
+  end
+
+  def collect
+    result = {
+      "vm" => unit_stats(
+        @vm_name,
+        with_io: false,    # Actual IO is done by the vhost block backend of each disk
+        with_memory: false # VM uses hugepages, so memory usage is not reflected in the process RSS
+      )
+    }
+    ubiblk_disks.each do |disk_index|
+      result["disk_#{disk_index}"] =
+        unit_stats("#{@vm_name}-#{disk_index}-storage", with_io: true, with_memory: true)
+    end
+
+    result
+  end
+
+  def unit_property(unit, name)
+    output = (r "systemctl", "show", unit, "--property", name).strip
+    raise "unexpected output from systemctl show: \"#{output}\"" unless output.delete_prefix!("#{name}=")
+    output
+  end
+
+  def io_stats(main_pid)
+    stats = {}
+    File.foreach("/proc/#{main_pid}/io") do |line|
+      key, value = line.split(": ", 2)
+      case key
+      when "read_bytes", "write_bytes"
+        stats[key] = Integer(value, 10)
+      end
+    end
+    stats
+  end
+
+  def cpu_stats(main_pid)
+    stat_contents = File.read("/proc/#{main_pid}/stat")
+
+    # skip pid and comm fields. comm can contain spaces, but is always wrapped
+    # in parentheses.
+    stat = stat_contents.rpartition(")").last.split
+
+    user_time_ms = (Integer(stat[11], 10) * 1000) / clk_tick
+    system_time_ms = (Integer(stat[12], 10) * 1000) / clk_tick
+    total_time_ms = user_time_ms + system_time_ms
+    {
+      "user_time_ms" => user_time_ms,
+      "system_time_ms" => system_time_ms,
+      "total_time_ms" => total_time_ms
+    }
+  end
+
+  def unit_stats(unit_name, with_io: false, with_memory: false)
+    main_pid = unit_property(unit_name, "MainPID")
+    h = {
+      "main_pid" => main_pid,
+      "cpu_stats" => cpu_stats(main_pid)
+    }
+    if with_memory
+      h["memory_peak_bytes"] = Integer(unit_property(unit_name, "MemoryPeak"), 10)
+      h["memory_swap_peak_bytes"] = Integer(unit_property(unit_name, "MemorySwapPeak"), 10)
+    end
+
+    h["io_stats"] = io_stats(main_pid) if with_io
+    h
+  end
+
+  def clk_tick
+    @clk_tick ||= Integer(r("getconf", "CLK_TCK"), 10)
+  end
+
+  def ubiblk_disks
+    @ubiblk_disks ||= begin
+      vm_path = VmPath.new(@vm_name)
+      params = JSON.parse(File.read(vm_path.prep_json))
+
+      params.fetch("storage_volumes").filter_map do |sv|
+        sv["disk_index"] if sv["vhost_block_backend_version"]
+      end
+    end
+  end
+end

--- a/rhizome/host/spec/vm_stats_spec.rb
+++ b/rhizome/host/spec/vm_stats_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+require_relative "../lib/vm_stats"
+
+RSpec.describe VmStats do
+  let(:vm_stats) { described_class.new("vmh6b1sz") }
+
+  before do
+    allow(vm_stats).to receive(:r).with("getconf", "CLK_TCK").and_return("100\n")
+  end
+
+  def stub_unit_property(unit, property, value)
+    allow(vm_stats).to receive(:r)
+      .with("systemctl", "show", unit, "--property", property)
+      .and_return("#{property}=#{value}\n")
+  end
+
+  describe "#collect" do
+    it "collects stats for the VM and its disks" do
+      stub_unit_property("vmh6b1sz", "MainPID", "3373")
+      stub_unit_property("vmh6b1sz-0-storage", "MainPID", "3350")
+      stub_unit_property("vmh6b1sz-0-storage", "MemoryPeak", "51892224")
+      stub_unit_property("vmh6b1sz-0-storage", "MemorySwapPeak", "123879")
+      expect(File).to receive(:read).with("/proc/3373/stat").and_return("3373 (cloud-hyperviso) S 1 3373 3373 0 -1 4194560 1163 0 0 0 95143 16431 0 0 20 0 13 0 3364 8618754048 960 18446744073709551615 135770696667136 135770699811150 140729095742720 0 0 0 134234114 69632 1073759298 0 0 0 17 7 0 0 0 89566 0 135770700348320 135770700898816 93826017284096 140729095744653 140729095745099 140729095745099 140729095745483 0")
+      expect(File).to receive(:read).with("/proc/3350/stat").and_return("3350 (vhost-backend) S 1 3350 3350 0 -1 4194560 15183 45 31 0 16602 733 0 0 20 0 7 0 3351 17248038912 10371 18446744073709551615 140535920156672 140535933113610 140725366025408 0 0 0 0 4096 1088 0 0 0 17 7 0 0 0 0 0 140535936046520 140535939797664 93825003057152 140725366033855 140725366033953 140725366033953 140725366034378 0")
+      expect(File).to receive(:foreach).with("/proc/3350/io")
+        .and_yield("rchar: 872010\n")
+        .and_yield("wchar: 1174987\n")
+        .and_yield("syscr: 34992\n")
+        .and_yield("syscw: 146630\n")
+        .and_yield("read_bytes: 1185382400\n")
+        .and_yield("write_bytes: 5457008640\n")
+        .and_yield("cancelled_write_bytes: 0\n")
+
+      expect(File).to receive(:read).with("/vm/vmh6b1sz/prep.json").and_return(JSON.generate(
+        {
+          "storage_volumes" => [
+            {
+              "boot" => true,
+              "image" => "ubuntu-noble",
+              "image_version" => "20250502.1",
+              "encrypted" => true,
+              "disk_index" => 0,
+              "vhost_block_backend_version" => "v0.4.0"
+            },
+            {
+              "disk_index" => 1,
+              "encrypted" => true
+            }
+          ]
+        }
+      ))
+
+      expect(vm_stats.collect).to eq(
+        {
+          "vm" => {
+            "main_pid" => "3373",
+            "cpu_stats" => {
+              "user_time_ms" => 951430,
+              "system_time_ms" => 164310,
+              "total_time_ms" => 1115740
+            }
+          },
+          "disk_0" => {
+            "main_pid" => "3350",
+            "memory_peak_bytes" => 51892224,
+            "memory_swap_peak_bytes" => 123879,
+            "cpu_stats" => {
+              "user_time_ms" => 166020,
+              "system_time_ms" => 7330,
+              "total_time_ms" => 173350
+            },
+            "io_stats" => {
+              "read_bytes" => 1185382400,
+              "write_bytes" => 5457008640
+            }
+          }
+        }
+      )
+    end
+  end
+
+  describe "#unit_property" do
+    it "returns the value of the specified property for the given systemd unit" do
+      stub_unit_property("my-unit", "MainPID", "1234")
+      expect(vm_stats.unit_property("my-unit", "MainPID")).to eq("1234")
+    end
+
+    it "raises an error if the property is not found" do
+      expect(vm_stats).to receive(:r).with("systemctl", "show", "my-unit", "--property", "MainPID").and_return("\n")
+      expect { vm_stats.unit_property("my-unit", "MainPID") }.to raise_error(RuntimeError, "unexpected output from systemctl show: \"\"")
+    end
+  end
+
+  describe "#cpu_stats" do
+    it "returns the user, system, and total CPU time in milliseconds for the given PID" do
+      stat_content = "3162 (vhost-backend) S 1 3162 3162 0 -1 4194560 9766 45 10 0 10478 491 0 0 20 0 4 0 3174 68799508480 7680 18446744073709551615 130089075412992 130089077621693 140721008361056 0 0 0 0 4096 1088 0 0 0 17 55 0 0 0 0 0 130089077837464 130089078048960 93825782800384 140721008364963 140721008365100 140721008365100 140721008365514 0"
+      expect(File).to receive(:read).with("/proc/1234/stat").and_return(stat_content)
+      expect(vm_stats.cpu_stats("1234")).to eq({"user_time_ms" => 104780, "system_time_ms" => 4910, "total_time_ms" => 109690})
+    end
+
+    it "works even if comm has a name with spaces and parentheses" do
+      stat_content = "2386855 (weird (name) ) ) S 2385257 2386855 2385257 34818 2386856 4194304 157 0 0 0 192 321 0 0 20 0 1 0 23386827 5820416 384 18446744073709551615 109656114941952 109656114955953 140720420466848 0 0 0 0 0 0 1 0 0 17 40 0 0 0 0 0 109656114965456 109656114966680 109656563896320 140720420468187 140720420468214 140720420468214 140720420470754 0"
+      expect(File).to receive(:read).with("/proc/1234/stat").and_return(stat_content)
+      expect(vm_stats.cpu_stats("1234")).to eq({"user_time_ms" => 1920, "system_time_ms" => 3210, "total_time_ms" => 5130})
+    end
+  end
+
+  describe "#clk_tick" do
+    it "returns the number of clock ticks per second" do
+      expect(vm_stats).to receive(:r).with("getconf", "CLK_TCK").and_return("234\n")
+      expect(vm_stats.clk_tick).to eq(234)
+    end
+  end
+
+  describe "#ubiblk_disks" do
+    it "returns the list of disk indices for ubiblk disks" do
+      expect(File).to receive(:read).with("/vm/vmh6b1sz/prep.json").and_return(
+        JSON.generate({
+          "storage_volumes" => [
+            {"disk_index" => 0, "vhost_block_backend_version" => "v0.1"},
+            {"disk_index" => 1},
+            {"disk_index" => 2, "vhost_block_backend_version" => "v0.1"}
+          ]
+        })
+      )
+      expect(vm_stats.ubiblk_disks).to eq([0, 2])
+    end
+  end
+end

--- a/spec/prog/test/vm_spec.rb
+++ b/spec/prog/test/vm_spec.rb
@@ -176,7 +176,75 @@ RSpec.describe Prog::Test::Vm do
       expect(sshable).to receive(:_cmd).with("sudo chown ubi #{mount_path}")
       expect(sshable).to receive(:_cmd).with("dd if=/dev/urandom of=#{mount_path}/1.txt bs=512 count=10000")
       expect(sshable).to receive(:_cmd).with("sync #{mount_path}/1.txt")
-      expect { vm_test.verify_extra_disks }.to hop("stop_semaphore")
+      expect { vm_test.verify_extra_disks }.to hop("verify_vm_stats")
+    end
+  end
+
+  describe "#verify_vm_stats" do
+    let(:vm_host) {
+      sshable = Sshable.create
+      instance_double(VmHost, sshable:)
+    }
+
+    before {
+      allow(vm_test.vm).to receive_messages(vm_host:, inhost_name: "vm123456")
+    }
+
+    it "verifies vm stats and hops to stop_semaphore" do
+      vm_stats_output = {
+        "disk_0" => {
+          "main_pid" => "3162",
+          "memory_peak_bytes" => 40050688,
+          "memory_swap_peak_bytes" => 0,
+          "cpu_stats" => {"user_time_ms" => 104430, "system_time_ms" => 4900, "total_time_ms" => 109330},
+          "io_stats" => {"read_bytes" => 111111, "write_bytes" => 222222}
+        },
+        "vm" => {
+          "main_pid" => "1234",
+          "cpu_stats" => {"user_time_ms" => 104780, "system_time_ms" => 4910, "total_time_ms" => 109690}
+        }
+      }
+      expect(vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats vm123456").and_return(vm_stats_output.to_json)
+      expect { vm_test.verify_vm_stats }.to hop("stop_semaphore")
+    end
+
+    it "fails if expected keys are missing in vm-stats output" do
+      expect(vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats vm123456").and_return({unexpected_key: "value"}.to_json)
+      expect { vm_test.verify_vm_stats }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "missing expected keys in vm-stats output"})
+    end
+
+    it "fails if expected keys are missing in vm stats" do
+      vm_stats_output = {
+        "disk_0" => {
+          "main_pid" => "3162",
+          "memory_peak_bytes" => 40050688,
+          "memory_swap_peak_bytes" => 0,
+          "cpu_stats" => {"user_time_ms" => 104430, "system_time_ms" => 4900, "total_time_ms" => 109330},
+          "io_stats" => {"read_bytes" => 111111, "write_bytes" => 222222}
+        },
+        "vm" => {
+          "unexpected_key" => "value"
+        }
+      }
+      expect(vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats vm123456").and_return(vm_stats_output.to_json)
+      expect { vm_test.verify_vm_stats }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "missing expected keys in vm stats"})
+    end
+
+    it "fails if expected keys are missing in disk_0 stats" do
+      vm_stats_output = {
+        "disk_0" => {
+          "unexpected_key" => "value"
+        },
+        "vm" => {
+          "main_pid" => "1234",
+          "cpu_stats" => {"user_time_ms" => 104780, "system_time_ms" => 4910, "total_time_ms" => 109690}
+        }
+      }
+      expect(vm_host.sshable).to receive(:_cmd).with("sudo host/bin/vm-stats vm123456").and_return(vm_stats_output.to_json)
+      expect { vm_test.verify_vm_stats }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "missing expected keys in disk_0 stats"})
     end
   end
 

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -740,12 +740,14 @@ RSpec.describe Prog::Vm::Metal::Nexus do
 
       vm.active_billing_records.each { expect(it).to receive(:finalize).and_call_original }
       expect(vm.assigned_vm_address.active_billing_record).to receive(:finalize).and_call_original
+      expect(nx).to receive(:log_vm_stats)
       nx.before_destroy
     end
 
     it "skips stopping billing record if not found" do
       expect(vm.active_billing_records).to be_empty
       expect(vm.assigned_vm_address).to be_nil
+      expect(nx).to receive(:log_vm_stats)
       nx.before_destroy
     end
 
@@ -754,6 +756,7 @@ RSpec.describe Prog::Vm::Metal::Nexus do
       AssignedVmAddress.create(ip: "192.168.1.1", address_id: adr.id, dst_vm_id: vm.id)
       expect(vm.assigned_vm_address).not_to be_nil
       expect(vm.assigned_vm_address.active_billing_record).to be_nil
+      expect(nx).to receive(:log_vm_stats)
       nx.before_destroy
     end
   end
@@ -1281,6 +1284,26 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     it "fails when SSH fails" do
       expect(sshable).to receive(:_cmd).and_raise(Sshable::SshError.new("ssh failed", "", "", nil, nil))
       expect(nx.available?).to be false
+    end
+  end
+
+  describe "#log_vm_stats" do
+    it "logs stats" do
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/vm-stats #{vm.inhost_name}").and_return("{\"stats\": \"stats\"}")
+      expect(Clog).to receive(:emit).with("VM destroy stats", vm_destroy_stats: {"stats" => "stats"})
+      nx.log_vm_stats
+    end
+
+    it "logs an error when SSH fails" do
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/vm-stats #{vm.inhost_name}").and_raise(Sshable::SshError.new("ssh failed", "", "", nil, nil))
+      expect(Clog).to receive(:emit).with("Failed to collect VM destroy stats", failed_vm_destroy_stats: {exception: hash_including(class: "Sshable::SshError")})
+      nx.log_vm_stats
+    end
+
+    it "logs an error when vm-stats returns bad json" do
+      expect(sshable).to receive(:_cmd).with("sudo host/bin/vm-stats #{vm.inhost_name}").and_return("not a json")
+      expect(Clog).to receive(:emit).with("Failed to collect VM destroy stats", failed_vm_destroy_stats: {exception: hash_including(class: "JSON::ParserError")})
+      nx.log_vm_stats
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM runtime/disk stats collection and a vm-stats tool; destroy-time stats are logged automatically
  * Machine image support: stores, versions, archival workflow for metal VMs, and UBID type prefixes
  * PostgreSQL I/O throttling monitor/enforcer to manage disk throughput based on WAL backlog

* **Database**
  * Migrations adding machine image, store, version, and metal-version tables and constraints

* **Admin UI**
  * Admin pages for MachineImage, MachineImageStore, MachineImageVersion, MachineImageVersionMetal

* **Tests**
  * Extensive specs covering VM stats, destroy logging, machine image workflows, IO throttle, and admin pages

* **Chores**
  * New billing rates for inference embedding tokens (input/output)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->