### PR TITLE
Fix install_rhizome failure with non-ASCII characters

### DIFF
--- a/prog/install_rhizome.rb
+++ b/prog/install_rhizome.rb
@@ -12,6 +12,7 @@ class Prog::InstallRhizome < Prog::Base
 
   label def start
     tar = StringIO.new
+    tar.binmode
     file_hash_map = {} # pun intended
     Gem::Package::TarWriter.new(tar) do |writer|
       base = Config.root + "/rhizome"

--- a/spec/prog/install_rhizome_spec.rb
+++ b/spec/prog/install_rhizome_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe Prog::InstallRhizome do
       expect { ir.start }.to hop("install_gems")
     end
 
+    it "handles non-ascii content in tar" do
+      expect(ir.sshable).to receive(:_cmd) do |*args, **kwargs|
+        expect(kwargs[:stdin].encoding).to eq(Encoding::BINARY)
+      end
+      expect { ir.start }.to hop("install_gems")
+    end
+
     it "writes tar including specs" do
       sshable2 = Sshable.create
       ir_spec = described_class.new(Strand.create_with_id(sshable2, prog: "InstallRhizome", label: "start", stack: [{"target_folder" => "host", "install_specs" => true}]))


### PR DESCRIPTION
## Summary
- `StringIO.new` defaults to UTF-8 encoding, but tar content is binary data. When rhizome source files contain non-ASCII characters (e.g. UTF-8 multibyte), `tar.string` can produce an invalid encoding, causing `install_rhizome` to fail.
- Added `tar.binmode` to set the StringIO to binary encoding, ensuring the tar payload is handled correctly regardless of file content.
- Added a test verifying the tar payload uses binary encoding.

## Test plan
- [ ] Verify existing `install_rhizome_spec.rb` tests pass
- [ ] Confirm rhizome installation works when source files contain non-ASCII characters

https://claude.ai/code/session_01ERrhLZn7yAn2Fn48VrHnGE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tar archive operations to properly handle non-ASCII content and filenames during installation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->