### PR TITLE
Pykello/enc

### DIFF
--- a/lib/validation.rb
+++ b/lib/validation.rb
@@ -157,6 +157,9 @@ module Validation
       volume.each_key { |key|
         fail ValidationFailed.new({storage_volumes: "Invalid key: #{key}"}) unless allowed_keys.include?(key)
       }
+      if !volume.fetch(:encrypted, true) && !volume.fetch(:read_only, false)
+        fail ValidationFailed.new({storage_volumes: "Unencrypted non-read-only volumes are not allowed."})
+      end
     }
   end
 

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -24,11 +24,11 @@ class StorageVolume
 
   attr_reader :image_path, :read_only
   def initialize(vm_name, params)
+    fail "unencrypted non-read-only volumes are not supported" if !params["encrypted"] && !params["read_only"]
     @vm_name = vm_name
     @vhost_backend_version = params["vhost_block_backend_version"]
     @disk_index = params["disk_index"]
     @device_id = params["device_id"]
-    @encrypted = params["encrypted"]
     @disk_size_gib = params["size_gib"]
     @use_bdev_ubi = params["use_bdev_ubi"] || false
     @image_path = BootImage.new(params["image"], params["image_version"]).image_path if params["image"]
@@ -63,13 +63,17 @@ class StorageVolume
   end
 
   def prep(key_wrapping_secrets)
+    # VmSetup should prevent this from being called on read-only volumes, but
+    # check again to fail loudly if it is violated.
+    fail "Cannot prep read-only volumes" if @read_only
+
     # Device path is intended to be created by system admin, so fail loudly if
     # it doesn't exist
     fail "Storage device directory doesn't exist: #{sp.device_path}" if !File.exist?(sp.device_path)
 
     FileUtils.mkdir_p storage_dir
     FileUtils.chown @vm_name, @vm_name, storage_dir
-    encryption_key = setup_data_encryption_key(key_wrapping_secrets) if @encrypted
+    encryption_key = setup_data_encryption_key(key_wrapping_secrets)
 
     if @vhost_backend_version
       create_empty_disk_file
@@ -88,11 +92,9 @@ class StorageVolume
 
     if @use_bdev_ubi
       create_ubi_writespace(encryption_key)
-    elsif @encrypted
+    else
       create_empty_disk_file
       encrypted_image_copy(encryption_key, @image_path)
-    else
-      unencrypted_image_copy
     end
   end
 
@@ -117,7 +119,7 @@ class StorageVolume
   def vhost_backend_create_config(encryption_key, key_wrapping_secrets)
     if use_config_v2?
       write_config_file(sp.vhost_backend_stripe_source_config, v2_stripe_source_toml) if @image_path
-      write_config_file(sp.vhost_backend_secrets_config, v2_secrets_toml(encryption_key, key_wrapping_secrets)) if @encrypted
+      write_config_file(sp.vhost_backend_secrets_config, v2_secrets_toml(encryption_key, key_wrapping_secrets))
       write_config_file(sp.vhost_backend_config, v2_main_toml)
     else
       config = vhost_backend_config(encryption_key, key_wrapping_secrets)
@@ -134,17 +136,12 @@ class StorageVolume
 
   def vhost_backend_create_metadata(key_wrapping_secrets)
     metadata_path = sp.vhost_backend_metadata
-    config_path = sp.vhost_backend_config
 
     write_new_file(metadata_path, @vm_name) do |file|
       file.truncate(8 * 1024 * 1024)
     end
 
-    if @encrypted
-      vhost_backend_create_encrypted_metadata(key_wrapping_secrets)
-    else
-      r("sudo", "-u", @vm_name, vhost_backend.init_metadata_path, "-s", @stripe_sector_count_shift.to_s, "--config", config_path)
-    end
+    vhost_backend_create_encrypted_metadata(key_wrapping_secrets)
 
     sync_parent_dir(metadata_path)
   end
@@ -166,7 +163,7 @@ class StorageVolume
 
   def vhost_backend_create_service_file
     # v2 config embeds the kek pipe path in the TOML, so no --kek CLI arg needed
-    kek_arg = if @encrypted && !use_config_v2?
+    kek_arg = if !use_config_v2?
       "--kek #{sp.kek_pipe}"
     end
 
@@ -293,12 +290,10 @@ class StorageVolume
       config["metadata_path"] = sp.vhost_backend_metadata
     end
 
-    if @encrypted
-      key_encryption = StorageKeyEncryption.new(key_wrapping_secrets)
-      key1_wrapped_b64 = wrap_key_b64(key_encryption, encryption_key[:key])
-      key2_wrapped_b64 = wrap_key_b64(key_encryption, encryption_key[:key2])
-      config["encryption_key"] = [key1_wrapped_b64, key2_wrapped_b64]
-    end
+    key_encryption = StorageKeyEncryption.new(key_wrapping_secrets)
+    key1_wrapped_b64 = wrap_key_b64(key_encryption, encryption_key[:key])
+    key2_wrapped_b64 = wrap_key_b64(key_encryption, encryption_key[:key2])
+    config["encryption_key"] = [key1_wrapped_b64, key2_wrapped_b64]
 
     if @cpus
       config["cpus"] = @cpus
@@ -313,19 +308,14 @@ class StorageVolume
     sections << v2_include_section
     sections << v2_device_section
     sections << v2_tuning_section
-    sections << if @encrypted
-      v2_encryption_section
-    else
-      # unencrypted disks must be explicitly allowed in config v2.
-      v2_danger_zone_section
-    end
+    sections << v2_encryption_section
     sections.join("\n")
   end
 
   def v2_include_section
     includes = []
     includes << File.basename(sp.vhost_backend_stripe_source_config) if @image_path
-    includes << File.basename(sp.vhost_backend_secrets_config) if @encrypted
+    includes << File.basename(sp.vhost_backend_secrets_config)
     return "" if includes.empty?
     items = includes.map { |f| toml_str(f) }.join(", ")
     "include = [#{items}]\n"
@@ -361,14 +351,6 @@ class StorageVolume
       "xts_key.ref" => "xts-key"
     }
     toml_section("encryption", hash)
-  end
-
-  def v2_danger_zone_section
-    hash = {
-      "enabled" => true,
-      "allow_unencrypted_disk" => true
-    }
-    toml_section("danger_zone", hash)
   end
 
   def v2_secrets_toml(encryption_key, key_wrapping_secrets)
@@ -429,12 +411,16 @@ class StorageVolume
   end
 
   def start(key_wrapping_secrets)
+    # VmSetup should prevent this from being called on read-only volumes, but
+    # check again to fail loudly if it is violated.
+    fail "Cannot start read-only volumes" if @read_only
+
     if @vhost_backend_version
       vhost_backend_start(key_wrapping_secrets)
       return
     end
 
-    encryption_key = read_data_encryption_key(key_wrapping_secrets) if @encrypted
+    encryption_key = read_data_encryption_key(key_wrapping_secrets)
     retries = 0
     begin
       setup_spdk_bdev(encryption_key)
@@ -458,11 +444,6 @@ class StorageVolume
 
     rm_if_exists(vhost_sock)
     rm_if_exists(sp.rpc_socket_path)
-
-    unless @encrypted
-      r "systemctl", "start", vhost_user_block_service
-      return
-    end
 
     with_kek_pipe(sp.kek_pipe, owner: @vm_name) do |kek_pipe|
       r "systemctl", "start", vhost_user_block_service
@@ -495,13 +476,9 @@ class StorageVolume
       rpc_client.bdev_ubi_delete(@device_id)
     end
 
-    if @encrypted
-      rpc_client.bdev_crypto_delete(non_ubi_bdev)
-      rpc_client.bdev_aio_delete("#{@device_id}_aio")
-      rpc_client.accel_crypto_key_destroy("#{@device_id}_key")
-    else
-      rpc_client.bdev_aio_delete(non_ubi_bdev)
-    end
+    rpc_client.bdev_crypto_delete(non_ubi_bdev)
+    rpc_client.bdev_aio_delete("#{@device_id}_aio")
+    rpc_client.accel_crypto_key_destroy("#{@device_id}_key")
 
     rm_if_exists(SpdkPath.vhost_sock(vhost_controller))
   end
@@ -532,16 +509,6 @@ class StorageVolume
   def read_data_encryption_key(key_wrapping_secrets)
     sek = StorageKeyEncryption.new(key_wrapping_secrets)
     sek.read_encrypted_dek(data_encryption_key_path)
-  end
-
-  def unencrypted_image_copy
-    q_image_path = @image_path.shellescape
-    q_disk_file = disk_file.shellescape
-
-    r "cp --reflink=auto #{q_image_path} #{q_disk_file}"
-    r "truncate -s #{@disk_size_gib}G #{q_disk_file}"
-
-    set_disk_file_permissions
   end
 
   def verify_imaged_disk_size
@@ -617,10 +584,8 @@ class StorageVolume
 
   def create_ubi_writespace(encryption_key)
     create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024 + 16)
-    if @encrypted
-      # just clear the metadata section, i.e. first 8MB
-      encrypted_image_copy(encryption_key, "/dev/zero", block_size: 2097152, count: 4)
-    end
+    # just clear the metadata section, i.e. first 8MB
+    encrypted_image_copy(encryption_key, "/dev/zero", block_size: 2097152, count: 4)
   end
 
   def create_empty_disk_file(disk_size_mib: @disk_size_gib * 1024)
@@ -643,20 +608,16 @@ class StorageVolume
   def setup_spdk_bdev(encryption_key)
     non_ubi_bdev = @use_bdev_ubi ? "#{@device_id}_base" : @device_id
 
-    if encryption_key
-      key_name = "#{@device_id}_key"
-      aio_bdev = "#{@device_id}_aio"
-      rpc_client.accel_crypto_key_create(
-        key_name,
-        encryption_key[:cipher],
-        encryption_key[:key],
-        encryption_key[:key2]
-      )
-      rpc_client.bdev_aio_create(aio_bdev, disk_file, 512)
-      rpc_client.bdev_crypto_create(non_ubi_bdev, aio_bdev, key_name)
-    else
-      rpc_client.bdev_aio_create(non_ubi_bdev, disk_file, 512)
-    end
+    key_name = "#{@device_id}_key"
+    aio_bdev = "#{@device_id}_aio"
+    rpc_client.accel_crypto_key_create(
+      key_name,
+      encryption_key[:cipher],
+      encryption_key[:key],
+      encryption_key[:key2]
+    )
+    rpc_client.bdev_aio_create(aio_bdev, disk_file, 512)
+    rpc_client.bdev_crypto_create(non_ubi_bdev, aio_bdev, key_name)
 
     if @use_bdev_ubi
       rpc_client.bdev_ubi_create(@device_id, non_ubi_bdev, @image_path)

--- a/rhizome/host/spec/storage_volume_spec.rb
+++ b/rhizome/host/spec/storage_volume_spec.rb
@@ -5,17 +5,6 @@ require "openssl"
 require "base64"
 
 RSpec.describe StorageVolume do
-  subject(:unencrypted_sv) {
-    params = {
-      "disk_index" => 2,
-      "device_id" => "xyz01",
-      "encrypted" => false,
-      "size_gib" => 12,
-      "image" => "kubuntu"
-    }
-    described_class.new("test", params)
-  }
-
   let(:encrypted_sv) {
     params = {
       "disk_index" => 2,
@@ -41,20 +30,6 @@ RSpec.describe StorageVolume do
     described_class.new("test", params)
   }
 
-  let(:unencrypted_vhost_sv) {
-    params = {
-      "disk_index" => 2,
-      "device_id" => "xyz01",
-      "encrypted" => false,
-      "size_gib" => 12,
-      "image" => "kubuntu",
-      "vhost_block_backend_version" => "v0.1-5",
-      "num_queues" => 4,
-      "queue_size" => 128
-    }
-    described_class.new("test", params)
-  }
-
   let(:encrypted_vhost_v2_sv) {
     params = {
       "disk_index" => 2,
@@ -69,25 +44,11 @@ RSpec.describe StorageVolume do
     described_class.new("test", params)
   }
 
-  let(:unencrypted_vhost_v2_sv) {
+  let(:encrypted_vhost_v2_with_cpus_sv) {
     params = {
       "disk_index" => 2,
       "device_id" => "xyz01",
-      "encrypted" => false,
-      "size_gib" => 12,
-      "image" => "kubuntu",
-      "vhost_block_backend_version" => "v0.4.0",
-      "num_queues" => 4,
-      "queue_size" => 128
-    }
-    described_class.new("test", params)
-  }
-
-  let(:unencrypted_vhost_v2_with_cpus_sv) {
-    params = {
-      "disk_index" => 2,
-      "device_id" => "xyz01",
-      "encrypted" => false,
+      "encrypted" => true,
       "size_gib" => 12,
       "image" => "kubuntu",
       "vhost_block_backend_version" => "v0.4.0",
@@ -110,19 +71,13 @@ RSpec.describe StorageVolume do
 
   before do
     allow(encrypted_sv).to receive(:rpc_client).and_return(rpc_client)
-    allow(unencrypted_sv).to receive(:rpc_client).and_return(rpc_client)
+  end
+
+  it "raises error if trying to create unencrypted non-read-only volume" do
+    expect { described_class.new("test", {"encrypted" => false}) }.to raise_error RuntimeError, "unencrypted non-read-only volumes are not supported"
   end
 
   describe "#prep" do
-    it "can prep a non-imaged unencrypted disk" do
-      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => false})
-      expect(File).to receive(:exist?).with("/var/storage").and_return(true)
-      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/1")
-      expect(FileUtils).to receive(:chown).with("test", "test", "/var/storage/test/1")
-      expect(vol).to receive(:create_empty_disk_file).with(no_args)
-      vol.prep(nil)
-    end
-
     it "can prep a non-imaged encrypted disk" do
       key_wrapping_secrets = "key_wrapping_secrets"
       vol = described_class.new("test", {"disk_index" => 1, "encrypted" => true})
@@ -136,7 +91,7 @@ RSpec.describe StorageVolume do
 
     it "fails if storage root doesn't exist" do
       dev_path = "/var/storage/devices/dev01"
-      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => false, "storage_device" => "dev01"})
+      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => true, "storage_device" => "dev01"})
       expect(File).to receive(:exist?).with(dev_path).and_return(false)
       expect { vol.prep(nil) }.to raise_error RuntimeError, "Storage device directory doesn't exist: #{dev_path}"
     end
@@ -154,15 +109,6 @@ RSpec.describe StorageVolume do
       encrypted_sv.prep(key_wrapping_secrets)
     end
 
-    it "can prep an unencrypted imaged disk" do
-      expect(FileUtils).to receive(:mkdir_p).with("/var/storage/test/2")
-      expect(FileUtils).to receive(:chown).with("test", "test", "/var/storage/test/2")
-      expect(File).to receive(:exist?).with("/var/storage").and_return(true)
-      expect(unencrypted_sv).to receive(:verify_imaged_disk_size).with(no_args)
-      expect(unencrypted_sv).to receive(:unencrypted_image_copy).with(no_args)
-      unencrypted_sv.prep(nil)
-    end
-
     it "can prep an encrypted imaged disk with vhost backend" do
       encryption_key = "test_key"
       key_wrapping_secrets = "key_wrapping_secrets"
@@ -173,6 +119,11 @@ RSpec.describe StorageVolume do
       expect(encrypted_vhost_sv).to receive(:create_empty_disk_file)
       expect(encrypted_vhost_sv).to receive(:prep_vhost_backend).with(encryption_key, key_wrapping_secrets)
       encrypted_vhost_sv.prep(key_wrapping_secrets)
+    end
+
+    it "fails to prep a read-only volume" do
+      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => true, "read_only" => true})
+      expect { vol.prep(nil) }.to raise_error RuntimeError, "Cannot prep read-only volumes"
     end
   end
 
@@ -187,39 +138,43 @@ RSpec.describe StorageVolume do
       encrypted_sv.start(key_wrapping_secrets)
     end
 
-    it "can start an uencrypted storage volume" do
-      expect(unencrypted_sv).to receive(:setup_spdk_bdev).with(nil)
-      expect(unencrypted_sv).to receive(:set_qos_limits).with(no_args)
-      expect(unencrypted_sv).to receive(:setup_spdk_vhost).with(no_args)
-      unencrypted_sv.start(nil)
-    end
-
     it "retries after purging if spdk artifacts exist" do
-      expect(unencrypted_sv).to receive(:setup_spdk_bdev).with(nil).and_return(nil, nil)
-      expect(unencrypted_sv).to receive(:set_qos_limits).with(no_args).and_return(nil, nil)
-      expect(unencrypted_sv).to receive(:setup_spdk_vhost).with(no_args).and_invoke(
+      encryption_key = "test_key"
+      key_wrapping_secrets = "key_wrapping_secrets"
+      expect(encrypted_sv).to receive(:read_data_encryption_key).with(key_wrapping_secrets).and_return(encryption_key)
+      expect(encrypted_sv).to receive(:setup_spdk_bdev).with(encryption_key).and_return(nil, nil)
+      expect(encrypted_sv).to receive(:set_qos_limits).with(no_args).and_return(nil, nil)
+      expect(encrypted_sv).to receive(:setup_spdk_vhost).with(no_args).and_invoke(
         -> { raise SpdkExists.new("Device Exists", -17) },
         -> {}
       )
-      expect(unencrypted_sv).to receive(:purge_spdk_artifacts)
-      unencrypted_sv.start(nil)
+      expect(encrypted_sv).to receive(:purge_spdk_artifacts)
+      encrypted_sv.start(key_wrapping_secrets)
     end
 
     it "doesn't retry more than once" do
-      expect(unencrypted_sv).to receive(:setup_spdk_bdev).with(nil).and_return(nil, nil)
-      expect(unencrypted_sv).to receive(:set_qos_limits).with(no_args).and_return(nil, nil)
-      expect(unencrypted_sv).to receive(:setup_spdk_vhost).with(no_args).and_invoke(
+      encryption_key = "test_key"
+      key_wrapping_secrets = "key_wrapping_secrets"
+      expect(encrypted_sv).to receive(:read_data_encryption_key).with(key_wrapping_secrets).and_return(encryption_key)
+      expect(encrypted_sv).to receive(:setup_spdk_bdev).with(encryption_key).and_return(nil, nil)
+      expect(encrypted_sv).to receive(:set_qos_limits).with(no_args).and_return(nil, nil)
+      expect(encrypted_sv).to receive(:setup_spdk_vhost).with(no_args).and_invoke(
         -> { raise SpdkExists.new("Device Exists", -17) },
         -> { raise SpdkExists.new("Device Exists", -17) }
       )
-      expect(unencrypted_sv).to receive(:purge_spdk_artifacts)
-      expect { unencrypted_sv.start(nil) }.to raise_error SpdkExists
+      expect(encrypted_sv).to receive(:purge_spdk_artifacts)
+      expect { encrypted_sv.start(key_wrapping_secrets) }.to raise_error SpdkExists
     end
 
     it "can start an encrypted storage volume with vhost backend" do
       key_wrapping_secrets = "key_wrapping_secrets"
       expect(encrypted_vhost_sv).to receive(:vhost_backend_start).with(key_wrapping_secrets)
       encrypted_vhost_sv.start(key_wrapping_secrets)
+    end
+
+    it "fails to start a read-only volume" do
+      vol = described_class.new("test", {"disk_index" => 1, "encrypted" => true, "read_only" => true})
+      expect { vol.start(nil) }.to raise_error RuntimeError, "Cannot start read-only volumes"
     end
   end
 
@@ -232,14 +187,6 @@ RSpec.describe StorageVolume do
       expect(FileUtils).to receive(:rm_r).with("/var/storage/vhost/test_2")
 
       encrypted_sv.purge_spdk_artifacts
-    end
-
-    it "can purge an unencrypted disk" do
-      expect(rpc_client).to receive(:vhost_delete_controller).with("test_2")
-      expect(rpc_client).to receive(:bdev_aio_delete).with("xyz01")
-      expect(FileUtils).to receive(:rm_r).with("/var/storage/vhost/test_2")
-
-      unencrypted_sv.purge_spdk_artifacts
     end
   end
 
@@ -267,27 +214,11 @@ RSpec.describe StorageVolume do
     end
   end
 
-  describe "#unencrypted_image_copy" do
-    it "can copy an image to an unencrypted volume" do
-      expect(unencrypted_sv).to receive(:r).with("cp --reflink=auto #{image_path} #{disk_file}")
-      expect(unencrypted_sv).to receive(:r).with("truncate -s 12G #{disk_file.shellescape}")
-      expect(unencrypted_sv).to receive(:set_disk_file_permissions)
-      unencrypted_sv.unencrypted_image_copy
-    end
-  end
-
   describe "#encrypted_image_copy" do
     it "can copy an image to an encrypted volume" do
       encryption_key = {cipher: "aes_xts", key: "key1value", key2: "key2value"}
       expect(encrypted_sv).to receive(:r).with(/spdk_dd.*--if #{image_path} --ob crypt0 --bs=[0-9]+\s*\z/, stdin: /{.*}/)
       encrypted_sv.encrypted_image_copy(encryption_key, image_path)
-    end
-  end
-
-  describe "#create_ubi_writespace" do
-    it "can create an unencrypted ubi writespace" do
-      expect(unencrypted_sv).to receive(:create_empty_disk_file).with(disk_size_mib: 12 * 1024 + 16)
-      unencrypted_sv.create_ubi_writespace(nil)
     end
   end
 
@@ -320,13 +251,6 @@ RSpec.describe StorageVolume do
       expect(rpc_client).to receive(:bdev_crypto_create).with(bdev, "#{bdev}_aio", "#{bdev}_key")
       encrypted_sv.setup_spdk_bdev(encryption_key)
     end
-
-    it "can setup unencrypted spdk bdev" do
-      bdev = "xyz01"
-      disk_file = "/var/storage/test/2/disk.raw"
-      expect(rpc_client).to receive(:bdev_aio_create).with(bdev, disk_file, 512)
-      unencrypted_sv.setup_spdk_bdev(nil)
-    end
   end
 
   describe "#set_qos_limits" do
@@ -335,7 +259,8 @@ RSpec.describe StorageVolume do
         "disk_index" => 1,
         "device_id" => "xyz01",
         "max_read_mbytes_per_sec" => 200,
-        "max_write_mbytes_per_sec" => 300
+        "max_write_mbytes_per_sec" => 300,
+        "encrypted" => true
       })
       rpc_client = instance_double(SpdkRpc)
       allow(sv).to receive(:rpc_client).and_return(rpc_client)
@@ -348,7 +273,8 @@ RSpec.describe StorageVolume do
     it "doesn't set qos limits if none are provided" do
       sv = described_class.new("test", {
         "disk_index" => 1,
-        "device_id" => "xyz01"
+        "device_id" => "xyz01",
+        "encrypted" => true
       })
       expect(sv).not_to receive(:rpc_client)
       sv.set_qos_limits
@@ -385,7 +311,7 @@ RSpec.describe StorageVolume do
 
   describe "#paths" do
     it "uses correct namespaced paths" do
-      sv = described_class.new("vm12345", {"storage_device" => "nvme0", "disk_index" => 3})
+      sv = described_class.new("vm12345", {"storage_device" => "nvme0", "disk_index" => 3, "encrypted" => true})
       expect(sv.storage_root).to eq("/var/storage/devices/nvme0/vm12345")
       expect(sv.storage_dir).to eq("/var/storage/devices/nvme0/vm12345/3")
       expect(sv.disk_file).to eq("/var/storage/devices/nvme0/vm12345/3/disk.raw")
@@ -394,7 +320,7 @@ RSpec.describe StorageVolume do
     end
 
     it "uses correct not-namespaced paths" do
-      sv = described_class.new("vm12345", {"storage_device" => "DEFAULT", "disk_index" => 3})
+      sv = described_class.new("vm12345", {"storage_device" => "DEFAULT", "disk_index" => 3, "encrypted" => true})
       expect(sv.storage_root).to eq("/var/storage/vm12345")
       expect(sv.storage_dir).to eq("/var/storage/vm12345/3")
       expect(sv.disk_file).to eq("/var/storage/vm12345/3/disk.raw")
@@ -415,19 +341,24 @@ RSpec.describe StorageVolume do
   end
 
   describe "#vhost_backend_create_config" do
-    it "can create vhost backend config" do
-      encryption_key = {
+    let(:encryption_key) {
+      {
         key: "abcdefgh01234567abcdefgh01234567",
         key2: "abcdefgh01234567abcdefgh01234567"
       }
+    }
+    let(:key_wrapping_secrets) {
       algorithm = "aes-256-gcm"
       cipher = OpenSSL::Cipher.new(algorithm)
-      key_wrapping_secrets = {
+      {
         "algorithm" => algorithm,
         "key" => Base64.encode64(cipher.random_key),
         "init_vector" => Base64.encode64(cipher.random_iv),
         "auth_data" => "Ubicloud-Test-Auth"
       }
+    }
+
+    it "can create vhost backend config" do
       config_path = "/var/storage/test/2/vhost-backend.conf"
       f = instance_double(File)
       allow(f).to receive(:path).and_return(config_path)
@@ -442,19 +373,6 @@ RSpec.describe StorageVolume do
     end
 
     it "creates v2 config files for v0.4.0" do
-      encryption_key = {
-        key: "abcdefgh01234567abcdefgh01234567",
-        key2: "abcdefgh01234567abcdefgh01234567"
-      }
-      algorithm = "aes-256-gcm"
-      cipher = OpenSSL::Cipher.new(algorithm)
-      key_wrapping_secrets = {
-        "algorithm" => algorithm,
-        "key" => Base64.encode64(cipher.random_key),
-        "init_vector" => Base64.encode64(cipher.random_iv),
-        "auth_data" => "Ubicloud-Test-Auth"
-      }
-
       expect(encrypted_vhost_v2_sv).to receive(:write_through_device?).and_return(true)
       expect(encrypted_vhost_v2_sv).to receive(:write_config_file)
         .with("/var/storage/test/2/vhost-backend-stripe-source.conf", /\[stripe_source\]/)
@@ -477,30 +395,17 @@ RSpec.describe StorageVolume do
     end
 
     it "writes cpu pinning as integer values in v2 config" do
-      expect(unencrypted_vhost_v2_with_cpus_sv).to receive(:write_through_device?).and_return(true)
-      expect(unencrypted_vhost_v2_with_cpus_sv).to receive(:write_config_file)
+      expect(encrypted_vhost_v2_with_cpus_sv).to receive(:write_through_device?).and_return(true)
+      expect(encrypted_vhost_v2_with_cpus_sv).to receive(:write_config_file)
         .with("/var/storage/test/2/vhost-backend-stripe-source.conf", /\[stripe_source\]/)
-      expect(unencrypted_vhost_v2_with_cpus_sv).to receive(:write_config_file)
+      expect(encrypted_vhost_v2_with_cpus_sv).to receive(:write_config_file)
         .with("/var/storage/test/2/vhost-backend.conf", satisfy { |content|
           content.include?("cpus = [0, 1]")
         })
+      expect(encrypted_vhost_v2_with_cpus_sv).to receive(:write_config_file)
+        .with("/var/storage/test/2/vhost-backend-secrets.conf", /\[secrets.xts-key\]/)
 
-      unencrypted_vhost_v2_with_cpus_sv.vhost_backend_create_config(nil, nil)
-    end
-
-    it "enables danger zone for unencrypted v2 config" do
-      expect(unencrypted_vhost_v2_sv).to receive(:write_through_device?).and_return(true)
-      expect(unencrypted_vhost_v2_sv).to receive(:write_config_file)
-        .with("/var/storage/test/2/vhost-backend-stripe-source.conf", /\[stripe_source\]/)
-      expect(unencrypted_vhost_v2_sv).to receive(:write_config_file)
-        .with("/var/storage/test/2/vhost-backend.conf", satisfy { |content|
-          lines = content.split("\n")
-          lines.include?("[danger_zone]") &&
-            lines.include?("enabled = true") &&
-            lines.include?("allow_unencrypted_disk = true")
-        })
-
-      unencrypted_vhost_v2_sv.vhost_backend_create_config(nil, nil)
+      encrypted_vhost_v2_with_cpus_sv.vhost_backend_create_config(encryption_key, key_wrapping_secrets)
     end
   end
 
@@ -552,21 +457,6 @@ RSpec.describe StorageVolume do
       allow(encrypted_vhost_sv).to receive(:sync_parent_dir).with(metadata_path)
       encrypted_vhost_sv.vhost_backend_create_metadata(key_wrapping_secrets)
     end
-
-    it "can create vhost backend metadata for unencrypted vhost" do
-      metadata_path = "/var/storage/test/2/metadata"
-      f = instance_double(File)
-      expect(unencrypted_vhost_sv).to receive(:write_new_file).with(metadata_path, "test").and_yield(f)
-      expect(f).to receive(:truncate).with(8 * 1024 * 1024)
-      expect(unencrypted_vhost_sv).to receive(:sync_parent_dir).with(metadata_path)
-      expect(unencrypted_vhost_sv).to receive(:r).with(
-        "sudo", "-u", "test",
-        "/opt/vhost-block-backend/v0.1-5/init-metadata",
-        "-s", "11", "--config",
-        "/var/storage/test/2/vhost-backend.conf"
-      )
-      unencrypted_vhost_sv.vhost_backend_create_metadata(nil)
-    end
   end
 
   describe "#vhost_backend_create_service_file" do
@@ -574,12 +464,6 @@ RSpec.describe StorageVolume do
       service_file = "/etc/systemd/system/test-2-storage.service"
       expect(File).to receive(:write).with(service_file, /vhost-backend.conf --kek/)
       encrypted_vhost_sv.vhost_backend_create_service_file
-    end
-
-    it "can create vhost backend service file for unencrypted vhost" do
-      service_file = "/etc/systemd/system/test-2-storage.service"
-      expect(File).to receive(:write).with(service_file, /vhost-backend\.conf \nRestart=no/)
-      unencrypted_vhost_sv.vhost_backend_create_service_file
     end
 
     it "does not add --kek to service file for encrypted v2 config" do
@@ -611,16 +495,6 @@ RSpec.describe StorageVolume do
       expect(encrypted_vhost_sv).to receive(:write_kek_to_pipe).with(kek_pipe, /aes256-gcm/)
       encrypted_vhost_sv.vhost_backend_start(key_wrapping_secrets)
     end
-
-    it "can start an unencrypted vhost backend" do
-      vhost_sock = "/var/storage/test/2/vhost.sock"
-      rpc_sock = "/var/storage/test/2/rpc.sock"
-      expect(unencrypted_vhost_sv).to receive(:rm_if_exists).with(vhost_sock)
-      expect(unencrypted_vhost_sv).to receive(:rm_if_exists).with(rpc_sock)
-      expect(unencrypted_vhost_sv).to receive(:r).with("systemctl", "stop", "test-2-storage.service")
-      expect(unencrypted_vhost_sv).to receive(:r).with("systemctl", "start", "test-2-storage.service")
-      unencrypted_vhost_sv.vhost_backend_start(nil)
-    end
   end
 
   describe "#systemd_io_rate_limits" do
@@ -629,7 +503,8 @@ RSpec.describe StorageVolume do
         "disk_index" => 1,
         "device_id" => "xyz01",
         "max_read_mbytes_per_sec" => 2000,
-        "max_write_mbytes_per_sec" => 3000
+        "max_write_mbytes_per_sec" => 3000,
+        "encrypted" => true
       })
       expect(sv).to receive(:persistent_device_id).with("/var/storage/test/1").and_return("/dev/disk/by-id/dev1")
       expect(sv.systemd_io_rate_limits).to eq(<<~RESULT
@@ -642,7 +517,8 @@ RSpec.describe StorageVolume do
     it "returns empty string if no rate limits are set" do
       sv = described_class.new("test", {
         "disk_index" => 1,
-        "device_id" => "xyz01"
+        "device_id" => "xyz01",
+        "encrypted" => true
       })
       expect(sv.systemd_io_rate_limits).to eq("")
     end

--- a/spec/lib/validation_spec.rb
+++ b/spec/lib/validation_spec.rb
@@ -139,6 +139,14 @@ RSpec.describe Validation do
       it "fails if contains an invalid key" do
         expect { described_class.validate_storage_volumes([xyz: 1], 0) }.to raise_error described_class::ValidationFailed
       end
+
+      it "fails if unencrypted and writable volume is included" do
+        expect { described_class.validate_storage_volumes([{encrypted: false, read_only: false}], 0) }.to raise_error described_class::ValidationFailed
+      end
+
+      it "succeeds if unencrypted volume is read-only" do
+        expect { described_class.validate_storage_volumes([{encrypted: false, read_only: true}], 0) }.not_to raise_error
+      end
     end
 
     describe "#validate_minio_username" do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Storage volumes must now be encrypted unless marked as read-only. Unencrypted writable volumes are rejected with an explicit validation error.
  * All storage operations now enforce encryption requirements and properly handle read-only volume constraints during preparation and startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->