### PR TITLE
UMI: Add prog to destroy MachineImageVersionMetal

### DIFF
--- a/model/machine_image/machine_image_version_metal.rb
+++ b/model/machine_image/machine_image_version_metal.rb
@@ -6,6 +6,7 @@ class MachineImageVersionMetal < Sequel::Model
   many_to_one :machine_image_version, key: :id, read_only: true, is_used: true
   many_to_one :store, class: :MachineImageStore, read_only: true
   many_to_one :archive_kek, class: :StorageKeyEncryptionKey, read_only: true
+  one_to_many :vm_storage_volumes, key: :machine_image_version_id, read_only: true
 
   plugin ResourceMethods, referencing: UBID::TYPE_MACHINE_IMAGE_VERSION
 end

--- a/prog/machine_image/destroy_version_metal.rb
+++ b/prog/machine_image/destroy_version_metal.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require "aws-sdk-s3"
+
+class Prog::MachineImage::DestroyVersionMetal < Prog::Base
+  subject_is :machine_image_version_metal
+
+  def self.assemble(machine_image_version_metal, destroy_version: true)
+    DB.transaction do
+      machine_image_version_metal.update(enabled: false)
+
+      miv = machine_image_version_metal.machine_image_version
+      if miv.machine_image.latest_version_id == miv.id
+        fail "Cannot destroy the latest version of a machine image"
+      end
+
+      unless machine_image_version_metal.vm_storage_volumes_dataset.empty?
+        fail "VMs are still using this machine image version"
+      end
+
+      Strand.create_with_id(machine_image_version_metal,
+        prog: "MachineImage::DestroyVersionMetal",
+        label: "destroy_objects",
+        stack: [{
+          "subject_id" => machine_image_version_metal.id,
+          "destroy_version" => destroy_version,
+        }])
+    end
+  end
+
+  label def destroy_objects
+    register_deadline(nil, 600)
+
+    mi_version = machine_image_version_metal.machine_image_version
+    store = machine_image_version_metal.store
+
+    s3_client = Aws::S3::Client.new(
+      access_key_id: store.access_key,
+      secret_access_key: store.secret_key,
+      endpoint: store.endpoint,
+      region: store.region,
+      force_path_style: true,
+    )
+
+    # delete one page of objects at a time to avoid a long running label
+    page = s3_client.list_objects_v2(
+      bucket: store.bucket,
+      prefix: machine_image_version_metal.store_prefix,
+      max_keys: 1000,
+    )
+
+    hop_update_database if page.contents.empty?
+
+    s3_client.delete_objects(
+      bucket: store.bucket,
+      delete: {
+        objects: page.contents.map { |obj| {key: obj.key} },
+      },
+    )
+
+    Clog.emit("Deleting machine image archive objects", {
+      machine_image: mi_version.machine_image.ubid,
+      version: mi_version.version,
+      count: page.contents.size,
+      truncated: page.is_truncated,
+    })
+
+    nap 0
+  end
+
+  label def update_database
+    version = machine_image_version_metal.machine_image_version
+    archive_kek = machine_image_version_metal.archive_kek
+    machine_image_version_metal.destroy
+    archive_kek.destroy
+    version.destroy if frame["destroy_version"]
+
+    pop "Metal machine image version is destroyed"
+  end
+end

--- a/scheduling/allocator.rb
+++ b/scheduling/allocator.rb
@@ -721,6 +721,14 @@ module Scheduling::Allocator
           allocate_boot_image(vm_host, volume["image"])
         end
 
+        if (miv_id = volume["machine_image_version_id"])
+          # Lock for update & check enabled to ensure the version doesn't get
+          # scheduled for deletion while we are allocating a storage volume
+          # based on it.
+          mivm = MachineImageVersionMetal.where(id: miv_id).for_update.first
+          fail "machine image version #{miv_id} is not available" unless mivm&.enabled
+        end
+
         VmStorageVolume.create(
           vm_id: vm.id,
           boot: volume["boot"],

--- a/spec/prog/machine_image/destroy_version_metal_spec.rb
+++ b/spec/prog/machine_image/destroy_version_metal_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require_relative "../../model/spec_helper"
+
+RSpec.describe Prog::MachineImage::DestroyVersionMetal do
+  subject(:prog) {
+    described_class.new(described_class.assemble(mi_version_metal, destroy_version: true))
+  }
+
+  let(:mi_version_metal) { create_machine_image_version_metal }
+  let(:mi_version) { mi_version_metal.machine_image_version }
+  let(:machine_image) { mi_version.machine_image }
+  let(:project) { machine_image.project }
+  let(:archive_kek) { mi_version_metal.archive_kek }
+  let(:store) { mi_version_metal.store }
+
+  describe ".assemble" do
+    it "disables the version metal and creates a strand" do
+      strand = described_class.assemble(mi_version_metal)
+
+      expect(mi_version_metal.reload.enabled).to be false
+      expect(strand.prog).to eq("MachineImage::DestroyVersionMetal")
+      expect(strand.label).to eq("destroy_objects")
+      expect(strand.stack.first["subject_id"]).to eq(mi_version_metal.id)
+      expect(strand.stack.first["destroy_version"]).to be true
+    end
+
+    it "passes destroy_version: false through to the stack" do
+      strand = described_class.assemble(mi_version_metal, destroy_version: false)
+
+      expect(strand.stack.first["destroy_version"]).to be false
+    end
+
+    it "fails when destroying the latest version of a machine image" do
+      machine_image.update(latest_version_id: mi_version.id)
+
+      expect {
+        described_class.assemble(mi_version_metal)
+      }.to raise_error("Cannot destroy the latest version of a machine image")
+    end
+
+    it "fails when VMs are still using this version" do
+      vm_host = create_vm_host
+      vhost_block_backend = create_vhost_block_backend(allocation_weight: 50, vm_host_id: vm_host.id)
+      vm = create_vm(vm_host_id: vm_host.id, project_id: project.id)
+      sd = StorageDevice.create(name: "vda", total_storage_gib: 100, available_storage_gib: 50, vm_host_id: vm_host.id)
+      VmStorageVolume.create(
+        vm_id: vm.id, boot: true, size_gib: 5, disk_index: 0,
+        storage_device_id: sd.id, vhost_block_backend_id: vhost_block_backend.id,
+        key_encryption_key_1_id: StorageKeyEncryptionKey.create_random(auth_data: "k1").id,
+        machine_image_version_id: mi_version.id,
+        vring_workers: 1,
+      )
+
+      expect {
+        described_class.assemble(mi_version_metal)
+      }.to raise_error("VMs are still using this machine image version")
+    end
+  end
+
+  describe "#destroy_objects" do
+    let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+
+    before do
+      allow(Aws::S3::Client).to receive(:new).with(
+        access_key_id: store.access_key,
+        secret_access_key: store.secret_key,
+        endpoint: store.endpoint,
+        region: store.region,
+        force_path_style: true,
+      ).and_return(s3_client)
+    end
+
+    it "hops to update_database when no objects are returned" do
+      s3_client.stub_responses(:list_objects_v2, {contents: [], is_truncated: false})
+
+      expect { prog.destroy_objects }.to hop("update_database")
+    end
+
+    it "deletes the first page of objects and naps" do
+      s3_client.stub_responses(
+        :list_objects_v2,
+        {contents: [{key: "obj1"}, {key: "obj2"}], is_truncated: true},
+        {contents: [{key: "obj3"}], is_truncated: false},
+      )
+      expect(s3_client).to receive(:delete_objects).with(
+        bucket: store.bucket,
+        delete: {objects: [{key: "obj1"}, {key: "obj2"}]},
+      ).and_call_original
+      expect(Clog).to receive(:emit).with(
+        "Deleting machine image archive objects",
+        {
+          machine_image: mi_version.machine_image.ubid,
+          version: mi_version.version,
+          count: 2,
+          truncated: true,
+        },
+      )
+
+      expect { prog.destroy_objects }.to nap(0)
+    end
+  end
+
+  describe "#update_database" do
+    it "destroys the version metal, archive kek, and version when destroy_version is true" do
+      mi_version_metal_id = mi_version_metal.id
+      kek_id = archive_kek.id
+      mi_version_id = mi_version.id
+
+      expect { prog.update_database }.to exit({"msg" => "Metal machine image version is destroyed"})
+
+      expect(MachineImageVersionMetal[mi_version_metal_id]).to be_nil
+      expect(StorageKeyEncryptionKey[kek_id]).to be_nil
+      expect(MachineImageVersion[mi_version_id]).to be_nil
+    end
+
+    it "preserves the underlying version when destroy_version is false" do
+      refresh_frame(prog, new_values: {"destroy_version" => false})
+
+      mi_version_metal_id = mi_version_metal.id
+      kek_id = archive_kek.id
+      mi_version_id = mi_version.id
+
+      expect { prog.update_database }.to exit({"msg" => "Metal machine image version is destroyed"})
+
+      expect(MachineImageVersionMetal[mi_version_metal_id]).to be_nil
+      expect(StorageKeyEncryptionKey[kek_id]).to be_nil
+      expect(MachineImageVersion[mi_version_id]).not_to be_nil
+    end
+  end
+end

--- a/spec/scheduling/allocator_spec.rb
+++ b/spec/scheduling/allocator_spec.rb
@@ -998,6 +998,34 @@ RSpec.describe Al do
       expect(vm.vm_storage_volumes.first.machine_image_version_id).to eq(miv.id)
     end
 
+    it "fails allocation when machine_image_version_id is set but the version is not enabled" do
+      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.4.0", allocation_weight: 100)
+      vm = create_vm
+      miv = create_machine_image_version_metal
+      miv.update(enabled: false)
+      vol = [{
+        "size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false,
+        "boot" => true, "machine_image_version_id" => miv.id,
+        "vring_workers" => 1,
+      }]
+      BootImage.dataset.destroy
+      expect { described_class.allocate(vm, vol) }.to raise_error(RuntimeError, /machine image version .* is not available/)
+    end
+
+    it "fails allocation when machine_image_version_id is set but the machine image version has been deleted" do
+      create_vhost_block_backend(vm_host_id: VmHost.first.id, version: "v0.4.0", allocation_weight: 100)
+      vm = create_vm
+      miv = create_machine_image_version_metal
+      vol = [{
+        "size_gib" => 5, "use_bdev_ubi" => false, "encrypted" => false,
+        "boot" => true, "machine_image_version_id" => miv.id,
+        "vring_workers" => 1,
+      }]
+      miv.destroy
+      BootImage.dataset.destroy
+      expect { described_class.allocate(vm, vol) }.to raise_error(RuntimeError, /machine image version .* is not available/)
+    end
+
     it "fails allocation when machine_image_version_id is set but no host has vhost block backend v0.4.0+" do
       vm = create_vm
       miv = create_machine_image_version_metal

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -283,7 +283,7 @@ RSpec.configure do |config|
       machine_image_id ||= MachineImage.create(name: "test-mi", project_id:, arch: "x64", location_id:).id
       miv = MachineImageVersion.create(machine_image_id:, version:)
       archive_kek = StorageKeyEncryptionKey.create_random(auth_data: "auth_data")
-      MachineImageVersionMetal.create_with_id(miv, archive_kek_id: archive_kek.id, store_id: machine_image_store_id, store_prefix:)
+      MachineImageVersionMetal.create_with_id(miv, archive_kek_id: archive_kek.id, store_id: machine_image_store_id, store_prefix:, enabled: true, archive_size_mib: 1024)
     end
 
     def create_vm_host_slice(**args)


### PR DESCRIPTION
Add a prog to free up the object store usage by the associated archive, and then destroy the related database records.

This can be invoked as follows:

```
st = Prog::MachineImage::DestroyVersionMetal.assemble(
       miv_metal, destroy_version: true
)
```

If `destroy_version` is set (default), then the associated `MachineImageVersion` object will also be deleted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safe machine image version deletion workflow that cleans up stored image objects and archive keys.
  * Machine image versions now surface related VM storage volumes.

* **Bug Fixes**
  * Allocation now prevents creating storage volumes from missing or disabled image versions.
  * Deletion now blocks removing latest versions or versions still referenced by active volumes.

* **Tests**
  * Added tests for deletion flows, validations, storage cleanup, and database updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->