### PR TITLE
Pykello/encrypt swap

### DIFF
--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -80,6 +80,13 @@ class Prog::Test::HetznerServer < Prog::Test::Base
     end
     update_stack({"available_storage_gib" => vm_host.available_storage_gib})
 
+    hop_verify_encrypted_swap
+  end
+
+  label def verify_encrypted_swap
+    sshable = vm_host.sshable
+    swap_device = sshable.cmd("swapon --show=NAME --noheadings").strip
+    fail_test "swap is not on a dm-crypt device: #{swap_device}" unless swap_device.start_with?("/dev/dm-")
     hop_install_integration_specs
   end
 

--- a/rhizome/host/bin/encrypt-swap
+++ b/rhizome/host/bin/encrypt-swap
@@ -1,0 +1,6 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/crypt_swap_setup"
+
+CryptSwapSetup.run

--- a/rhizome/host/bin/prep_host.rb
+++ b/rhizome/host/bin/prep_host.rb
@@ -4,6 +4,7 @@
 require_relative "../../common/lib/arch"
 require_relative "../../common/lib/util"
 require_relative "../lib/cloud_hypervisor"
+require_relative "../lib/crypt_swap_setup"
 require_relative "../lib/spdk_setup"
 require "fileutils"
 require "socket"
@@ -99,6 +100,8 @@ r "wget https://github.com/ubicloud/htcat/releases/download/v2.0.0-ubi1/htcat_2.
 r "tar xvf htcat.tar.gz -C /usr/local/bin/"
 
 SpdkSetup.prep
+
+CryptSwapSetup.run
 
 # cron job to store serial.log files
 FileUtils.mkdir_p("/var/log/ubicloud/serials")

--- a/rhizome/host/lib/crypt_swap_setup.rb
+++ b/rhizome/host/lib/crypt_swap_setup.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require_relative "../../common/lib/util"
+require_relative "device_resolver"
+
+require "fileutils"
+
+module CryptSwapSetup
+  extend DeviceResolver
+
+  module_function
+
+  FSTAB = "/etc/fstab"
+  CRYPTTAB = "/etc/crypttab"
+  CRYPTSWAP_DEVICE = "/dev/mapper/cryptswap"
+
+  def run
+    fstab = File.read(FSTAB)
+    swap_line = find_swap_line(fstab)
+    unless swap_line
+      puts "cryptswap already configured, skipping"
+      return
+    end
+
+    swap_real = resolve_swap_device(swap_line)
+    by_id = persistent_device_id(swap_real, device_node: true)
+
+    r "swapoff", swap_real
+
+    add_crypttab_entry("cryptswap #{by_id} /dev/urandom cipher=aes-xts-plain64,size=512,swap,discard\n")
+
+    fstab.sub!(swap_line, "#{CRYPTSWAP_DEVICE} none swap sw 0 0\n")
+    update_fstab(fstab)
+
+    activate(swap_real)
+  end
+
+  # Returns the active swap line from fstab, or nil if the swap is already
+  # backed by /dev/mapper/cryptswap. Raises if no swap entry exists.
+  def find_swap_line(fstab)
+    swap_lines = fstab.lines.reject { |l| l.match?(/\A\s*(#|\z)/) }
+      .select { |l| l.split[2] == "swap" }
+
+    fail "No swap line found in /etc/fstab" if swap_lines.empty?
+    return nil if swap_lines.any? { |l| l.split.first == CRYPTSWAP_DEVICE }
+
+    swap_lines.first
+  end
+
+  # Returns the realpath of the backing swap device.
+  def resolve_swap_device(swap_line)
+    source = swap_line.split.first
+      .sub(/\AUUID=/, "/dev/disk/by-uuid/")
+      .sub(/\ALABEL=/, "/dev/disk/by-label/")
+    File.realpath(source)
+  end
+
+  def add_crypttab_entry(entry)
+    existing = ""
+    if File.exist?(CRYPTTAB)
+      FileUtils.cp(CRYPTTAB, "#{CRYPTTAB}.bak.#{Time.now.to_i}")
+      existing = File.read(CRYPTTAB)
+    end
+    safe_write_to_file(CRYPTTAB, existing.gsub(/^cryptswap\s.*\n?/, "") + entry)
+  end
+
+  def update_fstab(fstab)
+    FileUtils.cp(FSTAB, "#{FSTAB}.bak.#{Time.now.to_i}")
+    safe_write_to_file(FSTAB, fstab)
+  end
+
+  def activate(swap_real)
+    # Prevent interactive prompt about existing swap signature on the backing device.
+    r "wipefs", "-a", swap_real
+    r "systemctl", "daemon-reload"
+    r "systemctl", "restart", "systemd-cryptsetup@cryptswap.service"
+    r "mkswap", "-f", CRYPTSWAP_DEVICE
+    r "swapon", "-a"
+  end
+end

--- a/rhizome/host/lib/device_resolver.rb
+++ b/rhizome/host/lib/device_resolver.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
 module DeviceResolver
-  def persistent_device_id(path)
+  # When `device_node` is false (default), `path` is expected to be a regular
+  # file or directory, and we match by the major/minor of the filesystem it
+  # lives on. When true, `path` points to a block-device node itself, so we
+  # must match by its rdev major/minor instead — otherwise we'd be comparing
+  # to the devtmpfs hosting /dev.
+  def persistent_device_id(path, device_node: false)
     path_stat = File.stat(path)
+    path_major = device_node ? path_stat.rdev_major : path_stat.dev_major
+    path_minor = device_node ? path_stat.rdev_minor : path_stat.dev_minor
 
     Dir["/dev/disk/by-id/*"].each do |id|
       dev_path = File.realpath(id)
       dev_stat = File.stat(dev_path)
-      next unless dev_stat.rdev_major == path_stat.dev_major && dev_stat.rdev_minor == path_stat.dev_minor
+      next unless dev_stat.rdev_major == path_major && dev_stat.rdev_minor == path_minor
 
       # Choose stable symlink types by subsystem:
       #  - SSDs: Use identifiers starting with 'wwn' (World Wide Name), globally unique.

--- a/rhizome/host/lib/device_resolver.rb
+++ b/rhizome/host/lib/device_resolver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module DeviceResolver
+  def persistent_device_id(path)
+    path_stat = File.stat(path)
+
+    Dir["/dev/disk/by-id/*"].each do |id|
+      dev_path = File.realpath(id)
+      dev_stat = File.stat(dev_path)
+      next unless dev_stat.rdev_major == path_stat.dev_major && dev_stat.rdev_minor == path_stat.dev_minor
+
+      # Choose stable symlink types by subsystem:
+      #  - SSDs: Use identifiers starting with 'wwn' (World Wide Name), globally unique.
+      #  - NVMe: Use identifiers starting with 'nvme-eui', also globally unique.
+      #  - MD devices: Use uuid identifiers.
+      #  - LVM/device-mapper: Use LVM uuid identifiers.
+      dev = File.basename(dev_path)
+      return id if (dev.start_with?("nvme") && id.include?("nvme-eui.")) ||
+        (dev.start_with?("sd") && id.include?("wwn-")) ||
+        (dev.start_with?("md") && id.include?("md-uuid-")) ||
+        (dev.start_with?("dm") && id.include?("dm-uuid-"))
+    rescue SystemCallError
+      next
+    end
+
+    raise "No persistent device ID found for storage path: #{path}"
+  end
+end

--- a/rhizome/host/lib/storage_volume.rb
+++ b/rhizome/host/lib/storage_volume.rb
@@ -8,6 +8,7 @@ require "openssl"
 require "base64"
 require "yaml"
 require_relative "boot_image"
+require_relative "device_resolver"
 require_relative "vm_path"
 require_relative "spdk_path"
 require_relative "spdk_rpc"
@@ -21,6 +22,7 @@ require_relative "vhost_block_backend"
 class StorageVolume
   include KekPipe
   include Toml
+  include DeviceResolver
 
   attr_reader :image_path, :read_only
   def initialize(vm_name, params)
@@ -259,31 +261,6 @@ class StorageVolume
     limits
       .map { |(key, mb)| "#{key}=#{dev} #{mb * 1024 * 1024}" }
       .join("\n")
-  end
-
-  def persistent_device_id(path)
-    path_stat = File.stat(path)
-
-    Dir["/dev/disk/by-id/*"].each do |id|
-      dev_path = File.realpath(id)
-      dev_stat = File.stat(dev_path)
-      next unless dev_stat.rdev_major == path_stat.dev_major && dev_stat.rdev_minor == path_stat.dev_minor
-
-      # Choose stable symlink types by subsystem:
-      #  - SSDs: Use identifiers starting with 'wwn' (World Wide Name), globally unique.
-      #  - NVMe: Use identifiers starting with 'nvme-eui', also globally unique.
-      #  - MD devices: Use uuid identifiers.
-      #  - LVM/device-mapper: Use LVM uuid identifiers.
-      dev = File.basename(dev_path)
-      return id if (dev.start_with?("nvme") && id.include?("nvme-eui.")) ||
-        (dev.start_with?("sd") && id.include?("wwn-")) ||
-        (dev.start_with?("md") && id.include?("md-uuid-")) ||
-        (dev.start_with?("dm") && id.include?("dm-uuid-"))
-    rescue SystemCallError
-      next
-    end
-
-    raise "No persistent device ID found for storage path: #{path}"
   end
 
   def wrap_key_b64(storage_key_encryption, key)

--- a/rhizome/host/spec/crypt_swap_setup_spec.rb
+++ b/rhizome/host/spec/crypt_swap_setup_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../lib/crypt_swap_setup"
+
+RSpec.describe CryptSwapSetup do
+  describe ".run" do
+    let(:fstab) {
+      <<~FSTAB
+            proc /proc proc defaults 0 0
+            # efi-boot-partiton
+            UUID=44F3-D390 /boot/efi vfat umask=0077 0 1
+            # /dev/nvme0n1p2
+            UUID=4c4fe278-d132-4136-8073-b1242eacf5eb none swap sw 0 0
+            # /dev/nvme0n1p3
+            UUID=5d7f632b-2776-48db-9ef5-86ab0a0222c7 /boot ext3 defaults 0 0
+            # /dev/nvme0n1p4
+            UUID=52ad6a6b-7eae-4ebe-ae19-6aab35d7f2fa / ext4 defaults 0 0
+            # /dev/nvme1n1
+            UUID=6e53e8d0-cbcd-40b0-852a-843c85eb48df /var/storage/devices/disk1 ext4 defaults 0 2
+            # /dev/nvme2n1
+            UUID=79464f09-9f05-4d05-8bca-77596c398a18 /var/storage/devices/disk2 ext4 defaults 0 2
+      FSTAB
+    }
+
+    it "configures encrypted swap" do
+      expect(File).to receive(:read).with(CryptSwapSetup::FSTAB).and_return(fstab.dup)
+      expect(File).to receive(:realpath).with("/dev/disk/by-uuid/4c4fe278-d132-4136-8073-b1242eacf5eb").and_return("/dev/nvme0n1p2")
+
+      expect(Dir).to receive(:[]).with("/dev/disk/by-id/*").and_return(["/dev/disk/by-id/nvme-eui.12345678", "/dev/disk/by-id/wwn-0x87654321"])
+      expect(File).to receive(:realpath).with("/dev/disk/by-id/nvme-eui.12345678").and_return("/dev/nvme0n1p2")
+      expect(File).to receive(:stat).with("/dev/nvme0n1p2").twice.and_return(instance_double(File::Stat, rdev_major: 259, rdev_minor: 2))
+
+      expect(described_class).to receive(:r).with("swapoff", "/dev/nvme0n1p2")
+      expect(File).to receive(:exist?).with(CryptSwapSetup::CRYPTTAB).and_return(false)
+      expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::CRYPTTAB, "cryptswap /dev/disk/by-id/nvme-eui.12345678 /dev/urandom cipher=aes-xts-plain64,size=512,swap,discard\n")
+      expect(FileUtils).to receive(:cp).with(CryptSwapSetup::FSTAB, "#{CryptSwapSetup::FSTAB}.bak.#{Time.now.to_i}")
+      expect(described_class).to receive(:safe_write_to_file).with(CryptSwapSetup::FSTAB, fstab.sub("UUID=4c4fe278-d132-4136-8073-b1242eacf5eb none swap sw 0 0\n", "/dev/mapper/cryptswap none swap sw 0 0\n"))
+
+      expect(described_class).to receive(:r).with("wipefs", "-a", "/dev/nvme0n1p2")
+      expect(described_class).to receive(:r).with("systemctl", "daemon-reload")
+      expect(described_class).to receive(:r).with("systemctl", "restart", "systemd-cryptsetup@cryptswap.service")
+      expect(described_class).to receive(:r).with("mkswap", "-f", CryptSwapSetup::CRYPTSWAP_DEVICE)
+      expect(described_class).to receive(:r).with("swapon", "-a")
+
+      described_class.run
+    end
+  end
+end

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -102,9 +102,22 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait_setup_host }.to nap(15)
     end
 
-    it "hops to install_integration_specs if the host is ready" do
+    it "hops to verify_encrypted_swap if the host is ready" do
       vm_host.strand.update(label: "wait")
-      expect { hs_test.wait_setup_host }.to hop("install_integration_specs")
+      expect { hs_test.wait_setup_host }.to hop("verify_encrypted_swap")
+    end
+  end
+
+  describe "#verify_encrypted_swap" do
+    it "hops to install_integration_specs if swap is on dm-crypt" do
+      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("swapon --show=NAME --noheadings").and_return("/dev/dm-0\n")
+      expect { hs_test.verify_encrypted_swap }.to hop("install_integration_specs")
+    end
+
+    it "fails if swap is not on dm-crypt" do
+      expect(hs_test.vm_host.sshable).to receive(:_cmd).with("swapon --show=NAME --noheadings").and_return("/dev/nvme0n1p2\n")
+      expect(hs_test.strand).to receive(:update).with(hash_including(exitval: {msg: "swap is not on a dm-crypt device: /dev/nvme0n1p2"}))
+      expect { hs_test.verify_encrypted_swap }.to hop("failed")
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host setup now configures and activates encrypted (dm-crypt) swap and integrates this into host preparation.
  * Added a command-line tool to initialize encrypted swap on hosts.

* **Tests**
  * New automated tests verify encrypted swap activation and include success/failure verification of the post-setup check.

* **Refactor**
  * Device identity resolution moved into a shared utility for reuse and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->