### PR TITLE
Use UMI for vanilla boot images whenever available

### DIFF
--- a/prog/vm/nexus.rb
+++ b/prog/vm/nexus.rb
@@ -53,12 +53,20 @@ class Prog::Vm::Nexus < Prog::Base
 
     Validation.validate_storage_volumes(storage_volumes, boot_disk_index)
 
+    metal_vm = location.provider_dispatcher_group_name == "metal"
+    boot_volume = storage_volumes[boot_disk_index]
+
     if boot_image.include?("@")
-      fail "Machine images are only supported for metal locations" unless location.provider_dispatcher_group_name == "metal"
+      fail "Machine images are only supported for metal locations" unless metal_vm
       image_name, image_version = boot_image.split("@", 2)
-      boot_volume = storage_volumes[boot_disk_index]
       machine_image_version = lookup_machine_image_version(project_id, location_id, image_name, image_version, boot_volume[:size_gib])
       boot_volume[:machine_image_version_id] = machine_image_version.id
+    elsif metal_vm && (mi_project_id = Config.machine_images_service_project_id)
+      # We want to eventually use machine images for base images. If a suitable
+      # machine image version isn't found, we'll fall back to using the
+      # boot_image as a name of a BootImage for now.
+      machine_image_version = lookup_machine_image_version(mi_project_id, location_id, boot_image, "latest", boot_volume[:size_gib], raise_on_invalid: false)
+      boot_volume[:machine_image_version_id] = machine_image_version&.id
     end
 
     ubid = Vm.generate_ubid
@@ -216,13 +224,14 @@ class Prog::Vm::Nexus < Prog::Base
     st
   end
 
-  def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib)
+  def self.lookup_machine_image_version(project_id, location_id, name, version, vm_boot_disk_size_gib, raise_on_invalid: true)
     search_ids = Option.machine_image_search_locations(location_id)
     mi = MachineImage
       .order(Sequel.function(:array_position, Sequel.pg_array(search_ids, :uuid), :location_id))
       .first(project_id:, location_id: search_ids, name:)
 
     unless mi
+      return nil unless raise_on_invalid
       search_locations = search_ids.map { |id| Location[id].display_name }.join(", ")
       fail Validation::ValidationFailed.new({machine_image: "Machine image with name \"#{name}\" does not exist in the specified project and any of the following locations: #{search_locations}"})
     end
@@ -233,9 +242,29 @@ class Prog::Vm::Nexus < Prog::Base
       MachineImageVersion.first(machine_image_id: mi.id, version:)
     end
 
-    fail Validation::ValidationFailed.new({machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\""}) unless miv
-    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" does not have an active metal version"}) unless miv.metal&.enabled
-    fail Validation::ValidationFailed.new({machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size"}) if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+    unless miv
+      return nil unless raise_on_invalid
+
+      fail Validation::ValidationFailed.new({
+        machine_image_version: "Version \"#{version}\" does not exist for machine image \"#{name}\"",
+      })
+    end
+
+    unless miv.metal&.enabled
+      return nil unless raise_on_invalid
+
+      fail Validation::ValidationFailed.new({
+        machine_image_version: "Machine image version \"#{version}\" does not have an active metal version",
+      })
+    end
+
+    if miv.actual_size_mib > vm_boot_disk_size_gib * 1024
+      return nil unless raise_on_invalid
+
+      fail Validation::ValidationFailed.new({
+        machine_image_version: "Machine image version \"#{version}\" is larger than the VM boot disk size",
+      })
+    end
 
     miv
   end

--- a/spec/prog/vm/metal/nexus_spec.rb
+++ b/spec/prog/vm/metal/nexus_spec.rb
@@ -284,6 +284,35 @@ RSpec.describe Prog::Vm::Metal::Nexus do
     end
   end
 
+  describe ".lookup_machine_image_version" do
+    let(:project_id) { Project.create(name: "test").id }
+    let(:miv) {
+      miv = create_machine_image_version_metal(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-jammy").machine_image_version
+      miv.machine_image.update(latest_version_id: miv.id)
+      miv
+    }
+
+    it "looks up the machine image version for the VM's location and image" do
+      miv
+      expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, raise_on_invalid: false)).to eq(miv)
+    end
+
+    it "returns nil if !raise_on_invalid and the machine image exists but no version is found" do
+      MachineImage.create(project_id:, location_id: Location::HETZNER_FSN1_ID, name: "ubuntu-noble", arch: "x64")
+      expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-noble", "latest", 10, raise_on_invalid: false)).to be_nil
+    end
+
+    it "returns nil if !raise_on_invalid and the requested version is not enabled" do
+      miv.metal.update(enabled: false)
+      expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, raise_on_invalid: false)).to be_nil
+    end
+
+    it "returns nil if !raise_on_invalid and the requested version is too large" do
+      miv.update(actual_size_mib: 20 * 1024)
+      expect(Prog::Vm::Nexus.lookup_machine_image_version(project_id, Location::HETZNER_FSN1_ID, "ubuntu-jammy", "latest", 10, raise_on_invalid: false)).to be_nil
+    end
+  end
+
   describe "#create_unix_user" do
     it "runs adduser" do
       expect(nx).to receive(:rand).and_return(1111)


### PR DESCRIPTION
If `Config.machine_images_service_project_id` has boot_image@latest and validates, use it. Otherwise, fallback to regular BootImage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced machine image resolution during VM provisioning with improved handling for different location types and optional fallback lookup capabilities.

* **Tests**
  * Added comprehensive test coverage for machine image version resolution scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->