### PR TITLE
Feat/mi billing rates

### DIFF
--- a/config/billing_rates/machine_image.yml
+++ b/config/billing_rates/machine_image.yml
@@ -1,0 +1,3 @@
+- { id: 7ccde1de-2f47-46ac-9bd4-b7e5c5cbbd6c, resource_type: MachineImageStorage, resource_family: standard, location: hetzner-fsn1,   unit_price: 0.0000000579, billed_by: duration, active_from: 2026-05-12T00:00:00Z, byoc: false }
+- { id: 13a06e23-05fd-4755-ae2e-7fd6962e70e6, resource_type: MachineImageStorage, resource_family: standard, location: hetzner-hel1,   unit_price: 0.0000000579, billed_by: duration, active_from: 2026-05-12T00:00:00Z, byoc: false }
+- { id: d95efd75-ea4e-434e-8054-37259d08f0be, resource_type: MachineImageStorage, resource_family: standard, location: leaseweb-wdc02, unit_price: 0.0000000579, billed_by: duration, active_from: 2026-05-12T00:00:00Z, byoc: false }

--- a/lib/billing_rate.rb
+++ b/lib/billing_rate.rb
@@ -78,6 +78,8 @@ class BillingRate
       "#{resource_family}-#{amount.to_i} backed Kubernetes Worker Node"
     when "KubernetesWorkerStorage"
       "#{amount.to_i} GiB Storage for Kubernetes Worker Node"
+    when "MachineImageStorage"
+      "#{amount.to_i} GiB Storage for Machine Image"
     else
       fail "BUG: Unknown resource type for line item description"
     end

--- a/model/machine_image/machine_image_version_metal.rb
+++ b/model/machine_image/machine_image_version_metal.rb
@@ -7,12 +7,27 @@ class MachineImageVersionMetal < Sequel::Model
   many_to_one :store, class: :MachineImageStore, read_only: true
   many_to_one :archive_kek, class: :StorageKeyEncryptionKey, read_only: true
   one_to_many :vm_storage_volumes, key: :machine_image_version_id, read_only: true
+  one_to_many :active_billing_records, class: :BillingRecord, key: :resource_id, read_only: true, &:active
 
   plugin ResourceMethods, referencing: UBID::TYPE_MACHINE_IMAGE_VERSION
 
   def display_state
     return "ready" if enabled
     archive_size_mib ? "destroying" : "creating"
+  end
+
+  def create_billing_record
+    project = machine_image_version.machine_image.project
+    return unless project.billable
+    rate = BillingRate.from_resource_properties("MachineImageStorage", "standard", machine_image_version.machine_image.location.name)
+    return unless rate
+    BillingRecord.create(
+      project_id: project.id,
+      resource_id: id,
+      resource_name: "#{machine_image_version.machine_image.name}:#{machine_image_version.version}",
+      billing_rate_id: rate["id"],
+      amount: archive_size_mib / 1024.0,
+    )
   end
 end
 

--- a/prog/machine_image/create_version_metal.rb
+++ b/prog/machine_image/create_version_metal.rb
@@ -78,6 +78,7 @@ class Prog::MachineImage::CreateVersionMetal < Prog::Base
       enabled: true,
       archive_size_mib: (frame["archive_size_bytes"]/1048576r).ceil,
     )
+    machine_image_version.metal.create_billing_record
     if frame["destroy_source_after"]
       source_vm.incr_destroy
     end

--- a/prog/machine_image/create_version_metal_from_url.rb
+++ b/prog/machine_image/create_version_metal_from_url.rb
@@ -77,6 +77,7 @@ class Prog::MachineImage::CreateVersionMetalFromUrl < Prog::Base
       enabled: true,
       archive_size_mib: (frame["physical_size_bytes"]/1048576r).ceil,
     )
+    machine_image_version.metal.create_billing_record
 
     machine_image_version.update(actual_size_mib: (frame["logical_size_bytes"]/1048576r).ceil)
 

--- a/prog/machine_image/destroy_version_metal.rb
+++ b/prog/machine_image/destroy_version_metal.rb
@@ -28,6 +28,7 @@ class Prog::MachineImage::DestroyVersionMetal < Prog::Base
       end
 
       machine_image_version_metal.update(enabled: false)
+      machine_image_version_metal.active_billing_records.each(&:finalize)
 
       Strand.create_with_id(machine_image_version_metal,
         prog: "MachineImage::DestroyVersionMetal",

--- a/spec/model/machine_image/machine_image_version_metal_spec.rb
+++ b/spec/model/machine_image/machine_image_version_metal_spec.rb
@@ -25,4 +25,26 @@ RSpec.describe MachineImageVersionMetal do
       expect(metal.display_state).to eq("destroying")
     end
   end
+
+  describe "#create_billing_record" do
+    let(:persisted_metal) { create_machine_image_version_metal(name: "ubuntu", version: "1.0") }
+
+    it "creates a billing record sized in GiB for the image archive" do
+      expect { persisted_metal.create_billing_record }.to change(BillingRecord, :count).by(1)
+      br = BillingRecord.where(resource_id: persisted_metal.id).first
+      expect(br.resource_name).to eq("ubuntu:1.0")
+      expect(br.amount).to eq(1)
+      expect(BillingRate.from_id(br.billing_rate_id)).to include("resource_type" => "MachineImageStorage", "location" => "hetzner-fsn1")
+    end
+
+    it "skips when project is not billable" do
+      persisted_metal.machine_image_version.machine_image.project.update(billable: false)
+      expect { persisted_metal.create_billing_record }.not_to change(BillingRecord, :count)
+    end
+
+    it "skips when no rate is configured for the location" do
+      expect(BillingRate).to receive(:from_resource_properties).and_return(nil)
+      expect { persisted_metal.create_billing_record }.not_to change(BillingRecord, :count)
+    end
+  end
 end

--- a/spec/prog/machine_image/destroy_version_metal_spec.rb
+++ b/spec/prog/machine_image/destroy_version_metal_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Prog::MachineImage::DestroyVersionMetal do
       expect(strand.label).to eq("destroy_objects")
     end
 
+    it "finalizes any active billing records for the version metal" do
+      br = mi_version_metal.create_billing_record
+      # Pre-date the lower bound so finalize produces a non-empty (non-zero-duration) range.
+      br.update(span: Sequel.pg_range((Time.now - 60)..))
+
+      described_class.assemble(mi_version_metal)
+      expect(br.reload.span.end).not_to be_nil
+    end
+
     it "fails when the version is still being created" do
       mi_version_metal.update(enabled: false, archive_size_mib: nil)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic billing for machine image storage: projects are now charged per GiB for machine image versions (rates effective 2026-05-12) and billing line items display storage-specific descriptions.
  * Billing records are created when metal image versions are finalized and finalized when versions are destroyed.

* **Tests**
  * Added tests covering billing-record creation, non-billable projects, missing rates, and finalization on destroy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pykello/ubicloud/pull/42)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->