### PR TITLE
Feat/vsv restart daemon

### DIFF
--- a/model/vm_storage_volume.rb
+++ b/model/vm_storage_volume.rb
@@ -90,6 +90,21 @@ class VmStorageVolume < Sequel::Model
       stdin: key_encryption_key_1.secret_key_material_hash.to_json,
     )
   end
+
+  def restart_daemon
+    fail "restart_daemon only supported for vm storage volumes with vhost block backend" unless vhost_block_backend
+    fail "restart_daemon requires an encrypted vm storage volume" unless key_encryption_key_1
+    fail "VM must be stopped before restarting the vhost backend daemon" unless ["stopped", "stopped by admin"].include?(vm.display_state)
+
+    vm.vm_host.sshable.cmd(
+      "sudo host/bin/storage-restart-daemon :vm_name :storage_device :disk_index :vhost_block_backend_version",
+      vm_name: vm.inhost_name,
+      storage_device: storage_device.name,
+      disk_index:,
+      vhost_block_backend_version: vhost_block_backend.version,
+      stdin: key_encryption_key_1.secret_key_material_hash.to_json,
+    )
+  end
 end
 
 # Table: vm_storage_volume

--- a/rhizome/host/bin/storage-restart-daemon
+++ b/rhizome/host/bin/storage-restart-daemon
@@ -1,0 +1,28 @@
+#!/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require_relative "../lib/storage_volume"
+
+unless ARGV.length == 4
+  puts "usage: storage-restart-daemon vm_name storage_device_name disk_index ubiblk_version"
+  exit 1
+end
+vm_name, device, disk_index, vhost_block_backend_version = ARGV
+
+key_wrapping_secrets = JSON.parse($stdin.read)
+
+unless key_wrapping_secrets["key"]
+  puts "expected key in stdin payload"
+  exit 1
+end
+
+StorageVolume.new(
+  vm_name,
+  {
+    "disk_index" => disk_index,
+    "storage_device" => device,
+    "encrypted" => true,
+    "vhost_block_backend_version" => vhost_block_backend_version,
+  },
+).vhost_backend_start(key_wrapping_secrets)

--- a/spec/model/vm_storage_volume_spec.rb
+++ b/spec/model/vm_storage_volume_spec.rb
@@ -160,4 +160,61 @@ RSpec.describe VmStorageVolume do
       expect { volume.dump_metadata }.to raise_error(RuntimeError, "dump_metadata only supported for vm storage volumes with vhost block backend version v0.4.0+")
     end
   end
+
+  describe "#restart_daemon" do
+    let(:vbb) { VhostBlockBackend.create(version_code: 400, allocation_weight: 100, vm_host_id: vm_host.id) }
+    let(:kek) { StorageKeyEncryptionKey.create_random(auth_data: "aad") }
+    let(:volume) do
+      described_class.create(
+        vm:,
+        disk_index: 1,
+        storage_device: default_storage_device,
+        vhost_block_backend_id: vbb.id,
+        key_encryption_key_1: kek,
+        boot: false,
+        size_gib: 10,
+        vring_workers: 1,
+      )
+    end
+    let(:strand) { Strand.create(prog: "Vm::Nexus", label: "stopped", stack: [{}]) { it.id = vm.id } }
+
+    before { strand }
+
+    it "runs storage-restart-daemon command with the kek as stdin" do
+      expect(volume.vm.vm_host.sshable).to receive(:_cmd).with(
+        "sudo host/bin/storage-restart-daemon #{vm.inhost_name} DEFAULT 1 v0.4.0",
+        stdin: kek.secret_key_material_hash.to_json,
+      ).and_return("")
+
+      volume.restart_daemon
+    end
+
+    it "accepts a VM stopped by admin" do
+      strand.update(label: "stopped_by_admin")
+      expect(volume.vm.vm_host.sshable).to receive(:_cmd).with(
+        "sudo host/bin/storage-restart-daemon #{vm.inhost_name} DEFAULT 1 v0.4.0",
+        stdin: kek.secret_key_material_hash.to_json,
+      ).and_return("")
+
+      volume.restart_daemon
+    end
+
+    it "fails when VM is not stopped" do
+      strand.update(label: "wait")
+
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "VM must be stopped before restarting the vhost backend daemon")
+    end
+
+    it "fails when volume is not encrypted" do
+      volume.update(key_encryption_key_1: nil)
+
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "restart_daemon requires an encrypted vm storage volume")
+    end
+
+    it "fails when volume does not have a vhost block backend" do
+      volume.update(vhost_block_backend_id: nil, vring_workers: nil)
+
+      expect { volume.restart_daemon }.to raise_error(RuntimeError, "restart_daemon only supported for vm storage volumes with vhost block backend")
+    end
+  end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Storage volumes now support remote daemon restart with enforced safety checks (VM must be stopped, encryption key required, vhost backend configured).

* **Tests**
  * Added comprehensive test coverage for the storage daemon restart functionality including validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pykello/ubicloud/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->