### PR TITLE
Hadi/mi e2e light

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -223,6 +223,11 @@ jobs:
         UBICLOUD_IMAGES_R2_ENDPOINT: ${{ secrets.UBICLOUD_IMAGES_R2_ENDPOINT }}
         UBICLOUD_IMAGES_R2_ACCESS_KEY: ${{ secrets.UBICLOUD_IMAGES_R2_ACCESS_KEY }}
         UBICLOUD_IMAGES_R2_SECRET_KEY: ${{ secrets.UBICLOUD_IMAGES_R2_SECRET_KEY }}
+        MACHINE_IMAGES_SERVICE_PROJECT_ID: ${{ secrets.E2E_MACHINE_IMAGES_SERVICE_PROJECT_ID }}
+        E2E_MACHINE_IMAGES_R2_ENDPOINT: ${{ secrets.E2E_MACHINE_IMAGES_R2_ENDPOINT }}
+        E2E_MACHINE_IMAGES_R2_BUCKET: ${{ secrets.E2E_MACHINE_IMAGES_R2_BUCKET }}
+        E2E_MACHINE_IMAGES_R2_ACCESS_KEY: ${{ secrets.E2E_MACHINE_IMAGES_R2_ACCESS_KEY }}
+        E2E_MACHINE_IMAGES_R2_SECRET_KEY: ${{ secrets.E2E_MACHINE_IMAGES_R2_SECRET_KEY }}
         GITHUB_APP_NAME: ${{ secrets.GH_APP_NAME }}
         GITHUB_APP_ID: ${{ secrets.GH_APP_ID }}
         GITHUB_APP_CLIENT_ID: ${{ secrets.GH_APP_CLIENT_ID }}
@@ -250,6 +255,18 @@ jobs:
       run: |
         set -o pipefail
         timeout 100m foreman start -m all=1,respirate=2 | tee foreman.log | grep --line-buffered -F "e2e.1"
+
+    - name: Empty e2e machine-image bucket
+      if: always() && env.METAL_PAUSED != 'true' && env.E2E_MACHINE_IMAGES_R2_BUCKET != ''
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.E2E_MACHINE_IMAGES_R2_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.E2E_MACHINE_IMAGES_R2_SECRET_KEY }}
+        AWS_DEFAULT_REGION: auto
+        E2E_MACHINE_IMAGES_R2_ENDPOINT: ${{ secrets.E2E_MACHINE_IMAGES_R2_ENDPOINT }}
+        E2E_MACHINE_IMAGES_R2_BUCKET: ${{ secrets.E2E_MACHINE_IMAGES_R2_BUCKET }}
+      run: |
+        aws --endpoint-url "$E2E_MACHINE_IMAGES_R2_ENDPOINT" \
+            s3 rm "s3://$E2E_MACHINE_IMAGES_R2_BUCKET/" --recursive
 
     - name: Print logs
       if: always() && env.METAL_PAUSED != 'true'

--- a/config.rb
+++ b/config.rb
@@ -243,6 +243,10 @@ module Config
   optional :e2e_aws_assume_role, string
   optional :e2e_gcp_credentials_base64_json, string, clear: true
   optional :e2e_cache_proxy_download_url, string
+  optional :e2e_machine_images_r2_endpoint, string
+  optional :e2e_machine_images_r2_bucket, string
+  optional :e2e_machine_images_r2_access_key, string, clear: true
+  optional :e2e_machine_images_r2_secret_key, string, clear: true
 
   # Local e2e
   optional :local_e2e_postgres_test_project_id, uuid

--- a/prog/test/hetzner_server.rb
+++ b/prog/test/hetzner_server.rb
@@ -7,6 +7,12 @@ class Prog::Test::HetznerServer < Prog::Test::Base
   frame_reader :server_id, :setup_host?, :default_boot_images, :provider_name
   frame_accessor :hostname, :vm_host_id, :available_storage_gib
 
+  # Stable so re-runs reuse the same MI row and therefore the same R2 prefix
+  # (<project_ubid>/<mi_ubid>/<version>/…), instead of accumulating one
+  # orphan prefix per run. The Project ubid comes from
+  # Config.machine_images_service_project_id (also stable across runs).
+  UBUNTU_NOBLE_MI_ID = "2a0309b4-3b54-8281-8497-0cf3ee783c68" # m1581gkd1vaj0gjbgswzef0y6g
+
   def self.assemble(vm_host_id: nil, default_boot_images: [])
     frame = if vm_host_id
       vm_host = VmHost[vm_host_id]
@@ -86,6 +92,49 @@ class Prog::Test::HetznerServer < Prog::Test::Base
       nap 15
     end
     self.available_storage_gib = vm_host.available_storage_gib + vm_host.boot_images.sum(&:size_gib)
+
+    hop_setup_machine_image
+  end
+
+  # Captures ubuntu-noble into the platform machine image store so the
+  # downstream VmGroup test can boot from it via the Config-driven
+  # service-project fallback in Vm::Nexus.assemble. Short-circuits to
+  # verify_encrypted_swap when any required Config isn't set, so the
+  # rest of the HetznerServer test still runs without MI infra.
+  label def setup_machine_image
+    hop_verify_encrypted_swap unless mi_test_enabled?
+
+    project = Project[Config.machine_images_service_project_id] ||
+      Project.create_with_id(Config.machine_images_service_project_id, name: "MachineImage-E2E-Service")
+
+    store = MachineImageStore.first(project_id: project.id, location_id: vm_host.location_id) ||
+      MachineImageStore.create(
+        project_id: project.id, location_id: vm_host.location_id,
+        provider: "r2", region: "auto",
+        endpoint: Config.e2e_machine_images_r2_endpoint,
+        bucket: Config.e2e_machine_images_r2_bucket,
+        access_key: Config.e2e_machine_images_r2_access_key,
+        secret_key: Config.e2e_machine_images_r2_secret_key,
+      )
+
+    mi = MachineImage[UBUNTU_NOBLE_MI_ID] ||
+      MachineImage.create_with_id(UBUNTU_NOBLE_MI_ID,
+        name: "ubuntu-noble", arch: vm_host.arch,
+        project_id: project.id, location_id: vm_host.location_id)
+
+    miv = mi.versions_dataset.where(version: ubuntu_noble_version).first
+    if miv.nil?
+      Prog::MachineImage::VersionMetalNexus.assemble_from_url(mi, ubuntu_noble_version,
+        ubuntu_noble_url, ubuntu_noble_sha256, store)
+    end
+
+    hop_wait_machine_image
+  end
+
+  label def wait_machine_image
+    miv = MachineImage[UBUNTU_NOBLE_MI_ID].versions_dataset.where(version: ubuntu_noble_version).first
+    fail_test "ubuntu-noble machine image archive failed" if miv&.metal&.status == "failed"
+    nap 30 unless miv&.metal&.status == "ready"
 
     hop_verify_encrypted_swap
   end
@@ -208,5 +257,35 @@ class Prog::Test::HetznerServer < Prog::Test::Base
 
   def vm_host
     @vm_host ||= VmHost[vm_host_id]
+  end
+
+  # Whether to capture a ubuntu-noble MI as part of the host setup.
+  # Requires both an R2 store config (so the archive has somewhere to land)
+  # and a service-project id (so Vm::Nexus.assemble's
+  # machine_images_service_project_id fallback can find the MI when
+  # downstream tests boot VMs with boot_image: "ubuntu-noble").
+  def mi_test_enabled?
+    Config.machine_images_service_project_id &&
+      Config.e2e_machine_images_r2_endpoint &&
+      Config.e2e_machine_images_r2_bucket &&
+      Config.e2e_machine_images_r2_access_key &&
+      Config.e2e_machine_images_r2_secret_key
+  end
+
+  def ubuntu_noble_versions
+    Prog::DownloadBootImage::BOOT_IMAGE_SHA256.fetch("ubuntu-noble").fetch(vm_host.arch)
+  end
+
+  def ubuntu_noble_version
+    @ubuntu_noble_version ||= ubuntu_noble_versions.keys.max
+  end
+
+  def ubuntu_noble_sha256
+    ubuntu_noble_versions.fetch(ubuntu_noble_version)
+  end
+
+  def ubuntu_noble_url
+    arch = vm_host.render_arch(arm64: "arm64", x64: "amd64")
+    "https://cloud-images.ubuntu.com/releases/noble/release-#{ubuntu_noble_version}/ubuntu-24.04-server-cloudimg-#{arch}.img"
   end
 end

--- a/prog/test/vm_group.rb
+++ b/prog/test/vm_group.rb
@@ -52,6 +52,28 @@ class Prog::Test::VmGroup < Prog::Test::Base
 
   label def wait_vms
     nap 10 if vms.any? { Vm[it].display_state != "running" }
+    hop_verify_machine_image_boot
+  end
+
+  # When Prog::Test::HetznerServer captured a ubuntu-noble MI, every
+  # subsequent assemble of a VM with boot_image: "ubuntu-noble" should pick
+  # up that MI via the Config.machine_images_service_project_id fallback
+  # in Vm::Nexus.assemble — i.e., the boot volume's machine_image_version_id
+  # should be set instead of the volume getting a plain BootImage. Short-
+  # circuits when the MI infra isn't configured so the rest of the group
+  # test still runs.
+  label def verify_machine_image_boot
+    if Config.machine_images_service_project_id && MachineImage.first(project_id: Config.machine_images_service_project_id, name: "ubuntu-noble")
+      mi_backed = vms.map { Vm[it] }.select { it.boot_image == "ubuntu-noble" }
+      fail_test "expected at least one ubuntu-noble VM to exercise the MI path" if mi_backed.empty?
+      mi_backed.each do |vm|
+        boot_vol = vm.vm_storage_volumes_dataset.first(boot: true)
+        unless boot_vol&.machine_image_version_id
+          fail_test "VM #{vm.ubid} (boot_image=ubuntu-noble) did not pick up the captured machine image"
+        end
+      end
+    end
+
     hop_verify_vms
   end
 

--- a/spec/prog/test/hetzner_server_spec.rb
+++ b/spec/prog/test/hetzner_server_spec.rb
@@ -102,9 +102,96 @@ RSpec.describe Prog::Test::HetznerServer do
       expect { hs_test.wait_setup_host }.to nap(15)
     end
 
-    it "hops to verify_encrypted_swap if the host is ready" do
+    it "hops to setup_machine_image if the host is ready" do
       vm_host.strand.update(label: "wait")
-      expect { hs_test.wait_setup_host }.to hop("verify_encrypted_swap")
+      expect { hs_test.wait_setup_host }.to hop("setup_machine_image")
+    end
+  end
+
+  describe "#setup_machine_image" do
+    let(:service_project_id) { "d61f57f2-83a4-82d2-9b42-7c395259b8ef" }
+    let(:noble_version) { Prog::DownloadBootImage::BOOT_IMAGE_SHA256.fetch("ubuntu-noble").fetch("x64").keys.max }
+
+    it "short-circuits to verify_encrypted_swap when MI configs are missing" do
+      expect { hs_test.setup_machine_image }.to hop("verify_encrypted_swap")
+      expect(MachineImage[described_class::UBUNTU_NOBLE_MI_ID]).to be_nil
+    end
+
+    context "with MI configs present" do
+      before do
+        vm_host.update(arch: "x64")
+        allow(Config).to receive_messages(
+          machine_images_service_project_id: service_project_id,
+          e2e_machine_images_r2_endpoint: "https://r2.example.com",
+          e2e_machine_images_r2_bucket: "e2e-test",
+          e2e_machine_images_r2_access_key: "ak",
+          e2e_machine_images_r2_secret_key: "sk",
+        )
+      end
+
+      it "creates project, store and machine image and triggers the capture" do
+        expect(Prog::MachineImage::VersionMetalNexus).to receive(:assemble_from_url) do |mi, version, url, sha, store|
+          expect(mi.id).to eq(described_class::UBUNTU_NOBLE_MI_ID)
+          expect(version).to eq(noble_version)
+          expect(url).to include("ubuntu-24.04-server-cloudimg-amd64").and include(noble_version)
+          expect(sha).to eq(Prog::DownloadBootImage::BOOT_IMAGE_SHA256.fetch("ubuntu-noble").fetch("x64").fetch(noble_version))
+          expect(store.project_id).to eq(service_project_id)
+        end
+        expect { hs_test.setup_machine_image }.to hop("wait_machine_image")
+        expect(Project[service_project_id]).not_to be_nil
+        expect(MachineImage[described_class::UBUNTU_NOBLE_MI_ID]).to have_attributes(name: "ubuntu-noble", arch: "x64")
+      end
+
+      it "skips assemble_from_url when a version row for the version already exists" do
+        project = Project.create_with_id(service_project_id, name: "MachineImage-E2E-Service")
+        store = MachineImageStore.create(project_id: project.id, location_id: vm_host.location_id,
+          provider: "r2", region: "auto", endpoint: "e", bucket: "b", access_key: "a", secret_key: "s")
+        mi = MachineImage.create_with_id(described_class::UBUNTU_NOBLE_MI_ID, name: "ubuntu-noble",
+          arch: "x64", project_id: project.id, location_id: vm_host.location_id)
+        MachineImageVersion.create(machine_image_id: mi.id, version: noble_version, actual_size_mib: 1024)
+
+        expect(Prog::MachineImage::VersionMetalNexus).not_to receive(:assemble_from_url)
+        expect { hs_test.setup_machine_image }.to hop("wait_machine_image")
+      end
+    end
+  end
+
+  describe "#wait_machine_image" do
+    let(:service_project_id) { "d61f57f2-83a4-82d2-9b42-7c395259b8ef" }
+    let(:noble_version) { Prog::DownloadBootImage::BOOT_IMAGE_SHA256.fetch("ubuntu-noble").fetch("x64").keys.max }
+    let(:project) { Project.create_with_id(service_project_id, name: "MachineImage-E2E-Service") }
+    let(:store) { MachineImageStore.create(project_id: project.id, location_id: vm_host.location_id, provider: "r2", region: "auto", endpoint: "e", bucket: "b", access_key: "a", secret_key: "s") }
+    let(:mi) { MachineImage.create_with_id(described_class::UBUNTU_NOBLE_MI_ID, name: "ubuntu-noble", arch: "x64", project_id: project.id, location_id: vm_host.location_id) }
+    let(:archive_kek) { StorageKeyEncryptionKey.create_random(auth_data: "k") }
+
+    before { vm_host.update(arch: "x64") }
+
+    def seed_metal(status:)
+      miv = MachineImageVersion.create(machine_image_id: mi.id, version: noble_version, actual_size_mib: 1024)
+      MachineImageVersionMetal.create_with_id(miv, status:,
+        archive_size_mib: (status == "ready") ? 1 : nil,
+        archive_kek_id: archive_kek.id, store_id: store.id, store_prefix: "p")
+    end
+
+    it "naps while the metal version is still creating" do
+      seed_metal(status: "creating")
+      expect { hs_test.wait_machine_image }.to nap(30)
+    end
+
+    it "naps when no metal version exists yet" do
+      mi
+      expect { hs_test.wait_machine_image }.to nap(30)
+    end
+
+    it "hops to verify_encrypted_swap once the metal version is ready" do
+      seed_metal(status: "ready")
+      expect { hs_test.wait_machine_image }.to hop("verify_encrypted_swap")
+    end
+
+    it "fails the test when the archive ends in 'failed'" do
+      seed_metal(status: "failed")
+      expect { hs_test.wait_machine_image }.to hop("failed")
+      expect(strand.reload.exitval).to eq({"msg" => "ubuntu-noble machine image archive failed"})
     end
   end
 

--- a/spec/prog/test/vm_group_spec.rb
+++ b/spec/prog/test/vm_group_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Prog::Test::VmGroup do
   end
 
   describe "#wait_vms" do
-    it "hops to verify_vms if vms are ready" do
+    it "hops to verify_machine_image_boot if vms are ready" do
       vm = create_vm(display_state: "running")
       refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
-      expect { vg_test.wait_vms }.to hop("verify_vms")
+      expect { vg_test.wait_vms }.to hop("verify_machine_image_boot")
     end
 
     it "naps if vms are not running" do
@@ -59,6 +59,54 @@ RSpec.describe Prog::Test::VmGroup do
       expect { vg_test.verify_vms }.to hop("wait_verify_vms")
       children = st.children_dataset.where(prog: "Test::Vm").all
       expect(children.map { it.stack.first.values_at("subject_id", "first_boot") }).to contain_exactly([vm1.id, true], [vm2.id, true])
+    end
+  end
+
+  describe "#verify_machine_image_boot" do
+    let(:service_project_id) { "d61f57f2-83a4-82d2-9b42-7c395259b8ef" }
+
+    it "hops straight to verify_vms when no MI service project is configured" do
+      refresh_frame(vg_test, new_values: {"vms" => []})
+      expect { vg_test.verify_machine_image_boot }.to hop("verify_vms")
+    end
+
+    it "hops to verify_vms when no ubuntu-noble MI exists in the service project" do
+      allow(Config).to receive(:machine_images_service_project_id).and_return(service_project_id)
+      refresh_frame(vg_test, new_values: {"vms" => []})
+      expect { vg_test.verify_machine_image_boot }.to hop("verify_vms")
+    end
+
+    context "with an ubuntu-noble MI captured in the service project" do
+      let(:project) { Project.create_with_id(service_project_id, name: "MachineImage-E2E-Service") }
+      let(:mi) { MachineImage.create_with_id("2a0309b4-3b54-8281-8497-0cf3ee783c68", name: "ubuntu-noble", arch: "x64", project_id: project.id, location_id: Location::HETZNER_FSN1_ID) }
+      let(:miv) { MachineImageVersion.create(machine_image_id: mi.id, version: "20260101", actual_size_mib: 1024) }
+
+      before do
+        allow(Config).to receive(:machine_images_service_project_id).and_return(service_project_id)
+        miv
+      end
+
+      it "passes when an ubuntu-noble VM has machine_image_version_id set on its boot volume" do
+        vm = create_vm(boot_image: "ubuntu-noble")
+        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 10, disk_index: 0, use_bdev_ubi: false, machine_image_version_id: miv.id)
+        refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
+        expect { vg_test.verify_machine_image_boot }.to hop("verify_vms")
+      end
+
+      it "fails when no ubuntu-noble VM exists in the group" do
+        vm = create_vm(boot_image: "ubuntu-jammy")
+        refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
+        expect { vg_test.verify_machine_image_boot }.to hop("failed")
+        expect(st.reload.exitval).to eq({"msg" => "expected at least one ubuntu-noble VM to exercise the MI path"})
+      end
+
+      it "fails when an ubuntu-noble VM has no machine_image_version_id set" do
+        vm = create_vm(boot_image: "ubuntu-noble")
+        VmStorageVolume.create(vm_id: vm.id, boot: true, size_gib: 10, disk_index: 0, use_bdev_ubi: false)
+        refresh_frame(vg_test, new_values: {"vms" => [vm.id]})
+        expect { vg_test.verify_machine_image_boot }.to hop("failed")
+        expect(st.reload.exitval["msg"]).to start_with("VM ").and end_with("(boot_image=ubuntu-noble) did not pick up the captured machine image")
+      end
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional machine-image configuration for E2E environments using R2-backed storage.
  * Expanded the E2E host setup flow to automatically prepare an Ubuntu Noble machine image when settings are available.
  * Added an extra VM verification stage to confirm running VMs boot from the expected machine image when enabled.

* **Bug Fixes**
  * Machine-image checks now safely skip when required configuration is missing.
  * Improved test coverage and failure messaging for machine-image creation readiness and VM boot validation.

* **Tests**
  * Added/extended E2E spec scenarios covering existing versions, readiness transitions, and failure states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->